### PR TITLE
Fixed parsing of extra version from some archive names and simplified the way we replace Source0 in new SPEC if needed (resolves issue #144)

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -174,8 +174,9 @@ class Application(object):
             self.rebase_spec_file.set_version_using_archive(self.conf.sources)
         else:
             logger.debug("argument passed as a new source is a version")
-            version, extra_version = SpecFile.split_version_string(self.conf.sources)
+            version, extra_version, separator = SpecFile.split_version_string(self.conf.sources)
             self.rebase_spec_file.set_version(version)
+            self.rebase_spec_file.set_extra_version_separator(separator)
             self.rebase_spec_file.set_extra_version(extra_version)
 
     def _initialize_data(self):

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -841,7 +841,7 @@ class SpecFile(object):
                 self.redefine_release_with_macro(extra_version_macro)
 
                 # change the Source0 definition
-                source0_re = re.compile(r'^Source0?:.*')
+                source0_re = re.compile(r'^Source0?:.+')
                 for index, line in enumerate(self.spec_content):
                     if source0_re.search(line):
                         # comment out the original Source0 line

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -831,7 +831,9 @@ class SpecFile(object):
             #  we need to create the extra version definition
             else:
                 # insert the REBASE_VER and REBASE_EXTRA_VER definitions
+                logger.debug("Adding new line to spec: %s", rebase_extra_version_def.strip())
                 self.spec_content.insert(0, rebase_extra_version_def)
+                logger.debug("Adding new line to spec: %s", new_extra_version_line.strip())
                 self.spec_content.insert(0, new_extra_version_line)
 
                 # change Release to 0.1 and append the extra version macro

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -937,7 +937,7 @@ class SpecFile(object):
         :param version_string: version string such as '1.1.1' or '1.2.3b1', ...
         :return: tuple of strings with (extracted version, extra version) or (None, None) if extraction failed
         """
-        version_split_regex_str = '([.0-9]+)(\w*)'
+        version_split_regex_str = '([0-9]+[.0-9]*)[_-]?(\w*)'
         version_split_regex = re.compile(version_split_regex_str)
         logger.debug("Splitting string '%s'", version_string)
         match = version_split_regex.search(version_string)

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -399,7 +399,8 @@ class SpecFile(object):
         :return: 
         """
         for line in self.spec_content:
-            match = re.search(r'^Release:\s*([0-9.]+).*%{\?dist}\s*', line)
+            # https://regexper.com/#%5ERelease%3A%5Cs*(%5B0-9%5D*%5C.%3F%5B0-9%5D%2B)(%5C..%2B)%3F%25%7B%5C%3Fdist%7D%5Cs*
+            match = re.search(r'^Release:\s*([0-9]*\.?[0-9]+)(\..+)?%{\?dist}\s*', line)
             if match:
                 return match.group(1)
 
@@ -707,7 +708,7 @@ class SpecFile(object):
         """
         for index, line in enumerate(self.spec_content):
             if line.startswith('Release:'):
-                new_release_line = re.sub(r'(Release:\s*[0-9.]*[0-9]+).*(%{\?dist}\s*)', r'\g<1>{0}\2'.format(macro),
+                new_release_line = re.sub(r'(Release:\s*[0-9.]*[0-9]+).*(%{\?dist}\s*)', r'\g<1>.{0}\2'.format(macro),
                                           line)
                 logger.debug("Commenting out original Release line '%s'", line.strip())
                 self.spec_content[index] = '#{0}'.format(line)
@@ -723,7 +724,7 @@ class SpecFile(object):
         :param macro: 
         :return: 
         """
-        search_re = re.compile('^Release:\s*[0-9.]*[0-9]+{0}%{{\?dist}}\s*'.format(macro))
+        search_re = re.compile('^Release:\s*[0-9.]*[0-9]+\.{0}%{{\?dist}}\s*'.format(macro))
 
         for index, line in enumerate(self.spec_content):
             match = search_re.search(line)

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -960,15 +960,17 @@ class SpecFile(object):
         :param source_string: Source string from SPEC file used to construct version extraction regex
         :return: tuple of strings with (extracted version, extra version) or (None, None) if extraction failed
         """
-        version_regex_str = '([.0-9]+\w*)'
-        fallback_regex_str = '^\w+-?_?v?{0}({1})'.format(version_regex_str,
-                                                         '|'.join(Archive.get_supported_archives()))
+        # https://regexper.com/#(%5B.0-9%5D%2B%5B-_%5D%3F%5Cw*)
+        version_regex_str = '([.0-9]+[-_]?\w*)'
+        fallback_regex_str = '^\w+[-_]?v?{0}({1})'.format(version_regex_str,
+                                                          '|'.join(Archive.get_supported_archives()))
         # match = re.search(regex, tarball_name)
         name = os.path.basename(archive_path)
         url_base = os.path.basename(source_string).strip()
 
         logger.debug("Extracting version from '%s' using '%s'", name, url_base)
-        regex_str = re.sub(r'%{version}', version_regex_str, url_base, flags=re.IGNORECASE)
+        # expect that the version macro can be followed by another macros
+        regex_str = re.sub(r'%{version}(%{.+})?', version_regex_str, url_base, flags=re.IGNORECASE)
 
         # if no substitution was made, use the fallback regex
         if regex_str == url_base:

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -352,7 +352,7 @@ class TestSpecFile(BaseTest):
         # the release number was changed
         assert self.SPEC_FILE_OBJECT.get_release_number() == '0.1'
         # the release string now contains the extra version
-        match = re.search(r'([0-9.]*[0-9]+)b1\w*', self.SPEC_FILE_OBJECT.get_release())
+        match = re.search(r'([0-9.]*[0-9]+)\.b1\w*', self.SPEC_FILE_OBJECT.get_release())
         assert match is not None
         assert match.group(1) == self.SPEC_FILE_OBJECT.get_release_number()
 
@@ -372,7 +372,7 @@ class TestSpecFile(BaseTest):
         with open(self.SPEC_FILE_OBJECT.get_path()) as f:
             while f.readline() != '#Release: 33%{?dist}\n':
                 pass
-            assert f.readline() == 'Release: 33' + macro + '%{?dist}\n'
+            assert f.readline() == 'Release: 33' + '.' + macro + '%{?dist}\n'
 
     def test_revert_redefine_release_with_macro(self):
         macro = '%{REBASE_VER}'

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -178,6 +178,8 @@ class TestSpecFile(BaseTest):
         assert SpecFile.split_version_string('1.0.1') == ('1.0.1', '')
         assert SpecFile.split_version_string('1.0.1b1') == ('1.0.1', 'b1')
         assert SpecFile.split_version_string('1.0.1rc1') == ('1.0.1', 'rc1')
+        assert SpecFile.split_version_string('1.1.3-rc6') == ('1.1.3', 'rc6')
+        assert SpecFile.split_version_string('.1.1.1') == ('1.1.1', '')
 
     def test_extract_version_from_archive_name(self):
         # Basic tests

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -200,6 +200,9 @@ class TestSpecFile(BaseTest):
         name = 'http://www.thekelleys.org.uk/dnsmasq/%{?extrapath}%{name}-%{version}%{?extraversion}.tar.xz'
         assert SpecFile.extract_version_from_archive_name('dnsmasq-2.69rc1.tar.xz',
                                                           name) == ('2.69', 'rc1')
+        name = 'http://downloads.sourceforge.net/%{name}/%{name}-%{version}%{?prever:-%{prever}}.tar.xz'
+        assert SpecFile.extract_version_from_archive_name('log4cplus-1.1.3-rc3.tar.xz',
+                                                          name) == ('1.1.3', 'rc3')
 
     def test__split_sections(self):
         expected_sections = {

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -174,35 +174,43 @@ class TestSpecFile(BaseTest):
         assert len(expected_paths.intersection(set(paths))) == len(expected_paths)
 
     def test_split_version_string(self):
-        assert SpecFile.split_version_string() == (None, None)
-        assert SpecFile.split_version_string('1.0.1') == ('1.0.1', '')
-        assert SpecFile.split_version_string('1.0.1b1') == ('1.0.1', 'b1')
-        assert SpecFile.split_version_string('1.0.1rc1') == ('1.0.1', 'rc1')
-        assert SpecFile.split_version_string('1.1.3-rc6') == ('1.1.3', 'rc6')
-        assert SpecFile.split_version_string('.1.1.1') == ('1.1.1', '')
+        assert SpecFile.split_version_string() == (None, None, None)
+        assert SpecFile.split_version_string('1.0.1') == ('1.0.1', '', '')
+        assert SpecFile.split_version_string('1.0.1b1') == ('1.0.1', 'b1', '')
+        assert SpecFile.split_version_string('1.0.1rc1') == ('1.0.1', 'rc1', '')
+        assert SpecFile.split_version_string('1.1.3-rc6') == ('1.1.3', 'rc6', '-')
+        assert SpecFile.split_version_string('1.1.3_rc6') == ('1.1.3', 'rc6', '_')
+        assert SpecFile.split_version_string('.1.1.1') == ('1.1.1', '', '')
 
     def test_extract_version_from_archive_name(self):
         # Basic tests
-        assert SpecFile.extract_version_from_archive_name('test-1.0.1.tar.gz') == ('1.0.1', '')
-        assert SpecFile.extract_version_from_archive_name('/home/user/test-1.0.1.tar.gz') == ('1.0.1', '')
+        assert SpecFile.extract_version_from_archive_name('test-1.0.1.tar.gz') == ('1.0.1', '', '')
+        assert SpecFile.extract_version_from_archive_name('/home/user/test-1.0.1.tar.gz') == ('1.0.1', '', '')
         assert SpecFile.extract_version_from_archive_name('test-1.0.1.tar.gz',
-                                                          'ftp://ftp.test.org/test-%{version}.tar.gz') == ('1.0.1', '')
+                                                          'ftp://ftp.test.org/test-%{version}.tar.gz') == ('1.0.1',
+                                                                                                           '',
+                                                                                                           '')
         assert SpecFile.extract_version_from_archive_name('/home/user/test-1.0.1.tar.gz',
-                                                          'ftp://ftp.test.org/test-%{version}.tar.gz') == ('1.0.1', '')
+                                                          'ftp://ftp.test.org/test-%{version}.tar.gz') == ('1.0.1',
+                                                                                                           '',
+                                                                                                           '')
         # Real world tests
         name = 'http://www.cups.org/software/%{version}/cups-%{version}-source.tar.bz2'
         assert SpecFile.extract_version_from_archive_name('cups-1.7.5-source.tar.bz2',
-                                                          name) == ('1.7.5', '')
+                                                          name) == ('1.7.5', '', '')
         # the 'rc1' can't be in the version number
         name = 'ftp://ftp.isc.org/isc/bind9/%{VERSION}/bind-%{VERSION}.tar.gz'
         assert SpecFile.extract_version_from_archive_name('bind-9.9.5rc2.tar.gz',
-                                                          name) == ('9.9.5', 'rc2')
+                                                          name) == ('9.9.5', 'rc2', '')
         name = 'http://www.thekelleys.org.uk/dnsmasq/%{?extrapath}%{name}-%{version}%{?extraversion}.tar.xz'
         assert SpecFile.extract_version_from_archive_name('dnsmasq-2.69rc1.tar.xz',
-                                                          name) == ('2.69', 'rc1')
+                                                          name) == ('2.69', 'rc1', '')
         name = 'http://downloads.sourceforge.net/%{name}/%{name}-%{version}%{?prever:-%{prever}}.tar.xz'
         assert SpecFile.extract_version_from_archive_name('log4cplus-1.1.3-rc3.tar.xz',
-                                                          name) == ('1.1.3', 'rc3')
+                                                          name) == ('1.1.3', 'rc3', '-')
+        name = 'http://downloads.sourceforge.net/%{name}/%{name}-%{version}%{?prever:_%{prever}}.tar.xz'
+        assert SpecFile.extract_version_from_archive_name('log4cplus-1.1.3_rc3.tar.xz',
+                                                          name) == ('1.1.3', 'rc3', '_')
 
     def test__split_sections(self):
         expected_sections = {


### PR DESCRIPTION
* Fixed parsing of extra version from some archive names
* Simplified the way we replace Source0 in new SPEC if needed
* Fixed the way we construct Release string when extra version is needed. Now it complies to Fedora Packaging guidelines.
* Resolves issue #144 

It just works :laughing: 