### PR TITLE
Rename fedpkg build tool to koji

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -30,7 +30,7 @@ Requirements
 - rpm-build
 - pkgdiff at least 1.6.3
 - python-six
-- fedpkg
+- koji
 - pyrpkg
 - libabigail
 

--- a/docs/upstreammonitoring.rst
+++ b/docs/upstreammonitoring.rst
@@ -23,7 +23,7 @@ Patch the new sources and run a koji scratch build
 
    from rebasehelper.application import Application
 
-   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', 'upstream_version'])
+   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'koji', 'upstream_version'])
    rh = Application(cli)
    rh.set_upstream_monitoring() # Switches the rebase-helper to an upstream release monitoring mode.
    rh.run()
@@ -31,18 +31,18 @@ Patch the new sources and run a koji scratch build
 
 - **Bash usage**
 
-  rebase-helper --non-interactive --builds-nowait --buildtool fedpkg upstream_version
+  rebase-helper --non-interactive --builds-nowait --buildtool koji upstream_version
 
 Download logs and RPMs for comparing with checkers
 --------------------------------------------------
 
 - **Python API usage**
 
-  cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', '--build-tasks', 'old_id,new-id'])
+  cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'koji', '--build-tasks', 'old_id,new-id'])
   rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
   rh.get_rebasehelper_data() # Gets all the information about the results
 
 - **Bash usage**
 
-   rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new-id
+   rebase-helper --non-interactive --builds-nowait --buildtool koji --build-tasks old_id,new-id
 

--- a/man/rebase-helper.1
+++ b/man/rebase-helper.1
@@ -22,7 +22,7 @@ apply patches to new upstream version
 .TP
 \fB\-\-buildtool\fR=\fIBUILDTOOL\fR
 tool for building old and new sources.
-Supported [mock (default), rpmbuild, fedpkg].
+Supported [mock (default), rpmbuild, koji, copr].
 
 .TP
 \fB\-\-pkgcomparetool\fR=\fIPKGCOMPARETOOL\fR

--- a/rebase-helper.bash
+++ b/rebase-helper.bash
@@ -21,7 +21,7 @@
 _local_archives()
 {
     # supported archive extensions
-    extensions=".tar.gz .tgz .tar.xz .tar.bz2 .zip"
+    extensions=".tar.gz .tgz .tar.xz .tar.bz2 .zip .gem"
     LOCAL_ARCHIVES=()
     for ext in $extensions; do
         LOCAL_ARCHIVES=("${LOCAL_ARCHIVES[@]}" $( ls | grep $ext\$ ))
@@ -31,10 +31,9 @@ _local_archives()
 # fill --*tool arguments into ARGUMENTS variable
 _complete_tool_arguments()
 {
-    buildtools="mock rpmbuild"
-    difftools="meld"
-    pkgcomparetools="pkgdiff"
-    outputtools="text"
+    buildtools="mock rpmbuild koji copr"
+    pkgcomparetools="pkgdiff rpmdiff abipkgdiff csmock"
+    outputtools="text json"
 
     if [ $# != 1 ]; then
         ARGUMENTS=()
@@ -58,12 +57,18 @@ _rebase-helper()
           -p --patch-only \
           -b --build-only \
           --buildtool \
-          --difftool \
           --pkgcomparetool \
           --outputtool \
           -w --keep-workspace \
           --not-download-sources \
-          -c --continue"
+          -c --continue \
+          --non-interactive \
+          --comparepkgs-only \
+          --builds-nowait \
+          --build-tasks \
+          --results-dir \
+          --build-retries \
+          --builder-options"
 
     # complete arguments of some commands
     case "${prev}" in

--- a/rebasehelper/build_helper.py
+++ b/rebasehelper/build_helper.py
@@ -462,12 +462,12 @@ class RpmbuildBuildTool(BuildToolBase):
 
 
 @register_build_tool
-class FedpkgBuildTool(BuildToolBase):
+class KojiBuildTool(BuildToolBase):
     """
-    Class representing rpmbuild build tool.
+    Class representing Koji build tool.
     """
 
-    CMD = "fedpkg"
+    CMD = "koji"
     logs = []
     koji_helper = None
 
@@ -524,7 +524,7 @@ class FedpkgBuildTool(BuildToolBase):
     def build(cls, spec, sources, patches, results_dir, **kwargs):
         """
         Builds the SRPM using rpmbuild
-        Builds the RPMs using fedpkg
+        Builds the RPMs using koji
 
         :param spec: absolute path to the SPEC file.
         :param sources: list with absolute paths to SOURCES

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -73,17 +73,19 @@ class CLI(object):
         self.parser.add_argument(
             "--buildtool",
             default="mock",
-            help="Select the build tool [mock(default)|rpmbuild|koji|copr]"
+            help="Select the build tool [mock, rpmbuild, koji, copr]. 'mock' is used by default."
         )
         self.parser.add_argument(
             "--pkgcomparetool",
             default=False,
-            help="Select the tool for comparing two packages [pkgdiff, rpmdiff, abipkgdiff, csmock]"
+            help="Select the tool for comparing two packages [pkgdiff, rpmdiff, abipkgdiff, csmock]. All compare tools"
+                 " are run by default."
         )
         self.parser.add_argument(
             "--outputtool",
             default="text",
-            help="Select the tool for showing information from rebase-helper process [text, json]"
+            help="Select the tool for showing information from rebase-helper process [text, json]. 'text' is used by"
+                 " default."
         )
         self.parser.add_argument(
             "-w",

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -73,7 +73,7 @@ class CLI(object):
         self.parser.add_argument(
             "--buildtool",
             default="mock",
-            help="Select the build tool [mock(default)|rpmbuild|fedpkg|copr]"
+            help="Select the build tool [mock(default)|rpmbuild|koji|copr]"
         )
         self.parser.add_argument(
             "--pkgcomparetool",
@@ -129,7 +129,7 @@ class CLI(object):
             default=False,
             action="store_true",
             help="It starts koji or copr builds and does not care how they finish. "
-                 "Useful for fedpkg and copr build tools."
+                 "Useful for koji and copr build tools."
         )
         # deprecated argument, kept for backward compatibility
         self.parser.add_argument(

--- a/workflow.txt
+++ b/workflow.txt
@@ -18,9 +18,6 @@ What is currently missing:
 - PatchHelper class - abstract class with at least one Patch Helper (mostly patch command)
 - DiffHelper class - abstract class with at least one Diff Helper (like vimdiff, Meld)
     - Each DiffHelper class can have different syntax
-- BuildHelper class - the class should implemented several method how to build up a package
-    - It can be done via mock, fedpkg local or brew.
-    - Be careful about dependecies in case of fedpkg local
 - RPMDiff class - use the class for getting information what was changed against previous version
 - Report class - it can be used for reporting things discovered during rebasing.
     - like what patches were changed.


### PR DESCRIPTION
We don't use fedpkg, the option is wrongly named.