### PR TITLE
Download old sources from Fedora lookaside cache

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -30,7 +30,8 @@ import argparse
 import shlex
 from datetime import date
 
-from rebasehelper.utils import DownloadHelper, DownloadError, MacroHelper, defenc
+from rebasehelper.utils import DownloadHelper, DownloadError, MacroHelper
+from rebasehelper.utils import LookasideCacheHelper, LookasideCacheError, defenc
 from rebasehelper.logger import logger
 from rebasehelper import settings
 from rebasehelper.archive import Archive
@@ -143,6 +144,13 @@ class SpecFile(object):
         self.prep_section = self.spc.prep
         # HEADER of SPEC file
         self.hdr = self.spc.sourceHeader
+
+        try:
+            # try to download old sources from Fedora lookaside cache
+            LookasideCacheHelper.download('fedpkg', os.path.dirname(self.path), self.get_package_name())
+        except LookasideCacheError as e:
+            logger.debug("Downloading old sources from lookaside cache failed. "
+                         "Reason: '{}'.".format(str(e)))
 
         # All source file mentioned in SPEC file Source[0-9]*
         self.rpm_sections = self._split_sections()

--- a/rebasehelper/tests/test_utils.py
+++ b/rebasehelper/tests/test_utils.py
@@ -40,6 +40,7 @@ from rebasehelper.utils import PathHelper
 from rebasehelper.utils import TemporaryEnvironment
 from rebasehelper.utils import RpmHelper
 from rebasehelper.utils import MacroHelper
+from rebasehelper.utils import LookasideCacheHelper
 
 
 class TestConsoleHelper(BaseTest):
@@ -629,3 +630,38 @@ class TestMacroHelper(BaseTest):
         assert macros[0]['name'] == 'test_macro'
         assert macros[0]['value'] == 'test_macro value'
         assert macros[0]['level'] == -1
+
+
+class TestLookasideCacheHelper(BaseTest):
+
+    SETUPS = [
+        {
+            'tool': 'fedpkg',
+            'package': 'vim-go',
+            'filename': 'v1.6.tar.gz',
+            'hashtype': 'md5',
+            'hash': '847d3e3577982a9515ad0aec6d5111b2',
+            'url': 'http://pkgs.fedoraproject.org/repo/pkgs',
+        },
+        {
+            'tool': 'fedpkg',
+            'package': 'rebase-helper',
+            'filename': '0.8.0.tar.gz',
+            'hashtype': 'md5',
+            'hash': '91de540caef64cb8aa7fd250f2627a93',
+            'url': 'http://pkgs.fedoraproject.org/repo/pkgs',
+        },
+    ]
+
+    @pytest.mark.parametrize('setup', SETUPS)
+    def test_download(self, setup):
+        target = os.path.basename(setup['filename'])
+        LookasideCacheHelper._download_source(setup['tool'],
+                                              setup['url'],
+                                              setup['package'],
+                                              setup['filename'],
+                                              setup['hashtype'],
+                                              setup['hash'],
+                                              target)
+        assert os.path.isfile(target)
+        assert LookasideCacheHelper._hash(target, setup['hashtype']) == setup['hash']


### PR DESCRIPTION
The `LookasideCacheHelper` class supports both Fedora and RHEL, but downloading from RHEL lookaside cache is functional only in Red Hat internal network. So I didn't enable it in rebase-helper for now. I also marked unit test setup for RHEL lookaside cache as *xfail*, but I can make it run only in case *pkgs.devel.redhat.com* domain is resolvable or remove it completely.

This PR partially resolves issue #198.