### PR TITLE
Documentation changes

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -114,7 +114,7 @@ text:
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
 man:
-	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	$(SPHINXBUILD) -b custom-man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 

--- a/docs/archive.rst
+++ b/docs/archive.rst
@@ -1,5 +1,5 @@
 Archive module
-===================
+==============
 
 .. automodule:: rebasehelper.archive
    :members:

--- a/docs/autoargs.py
+++ b/docs/autoargs.py
@@ -1,0 +1,394 @@
+import re
+import six
+
+from argparse import ArgumentParser, SUPPRESS
+
+from docutils import nodes
+from docutils.statemachine import StringList
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives import flag, positive_int, unchanged, unchanged_required
+from sphinx import addnodes
+from sphinx.errors import SphinxError
+
+
+class AutoArgsError(SphinxError):
+    """Base class for AutoArgs errors"""
+    category = 'autoargs extension error'
+
+
+class AutoArgsDirective(Directive):
+    """
+    Generates program synopsis, description and option list from
+    pre-configured ArgumentParser instance
+
+    All sections and every option description can be extended with
+    custom content
+
+    :param function: function returning pre-configured ArgumentParser instance
+    :param module: module containing the function
+    :param program_name: name of the program
+    :param synopsis_max_width: maximal width of synopsis (number of characters)
+    :param ignore_option_groups: do not render options in groups
+    """
+    option_spec = dict(function=unchanged_required,
+                       module=unchanged_required,
+                       program_name=unchanged,
+                       synopsis_max_width=positive_int,
+                       ignore_option_groups=flag)
+    has_content = True
+    synopsis_max_width = None
+    ignore_option_groups = False
+
+    @staticmethod
+    def _get_program_name(parser):
+        """Return sanitized program name"""
+        return re.sub(r'\s+', '-', parser.prog)
+
+    def _decorate_references(self, text):
+        """
+        Decorate string conversion specifiers which are used as references
+        to program name or action properties
+        """
+        # python string conversion specifier regex
+        template = r'(%\({}\)[#0\- +]?(\d+|\*)?(\.(\d+|\*))?[hlL]?[diouxXeEfFgGcrs%])'
+        replacements = dict(prog=r'\\ :program:`\1`\\ ',
+                            default=r'\\ ``\1``\\ ',
+                            metavar=r'\\ ``\1``\\ ')
+        for k, v in six.iteritems(replacements):
+            text = re.sub(template.format(k), v, text or '')
+        return text
+
+    def _format_synopsis(self, synopsis):
+        """
+        Format synopsis so it fits into maximal width
+
+        :param synopsis: synopsis text divided into non-breakable parts
+        :return: list of lines of formatted synopsis text
+        """
+        def len_plain(text):
+            text = re.sub(r':\w+:`(.+?)`', r'\1', text)
+            text = re.sub(r'([`*]{1,2})(.+?)\1', r'\2', text)
+            text = re.sub(r'\\ ', '', text)
+            return len(text)
+        result = []
+        line = [synopsis.pop(0)]
+        synopsis.reverse()
+        while synopsis:
+            line.append(synopsis.pop())
+            if len_plain(' '.join(line)) > self.synopsis_max_width and len(line) > 2:
+                synopsis.append(line.pop())
+                result.append(' '.join(line))
+                line = [' ']
+        result.append(' '.join(line))
+        return ['| {}'.format(l) for l in result]
+
+    @staticmethod
+    def _get_delimiter(fmt, action):
+        """
+        Extract delimiter from usage string formatted
+        by specified HelpFormatter
+        """
+        if not action.option_strings or action.nargs == 0:
+            return None
+        else:
+            usage = fmt._format_actions_usage([action], [])
+            option_string = action.option_strings[0]
+            idx = usage.find(option_string)
+            if idx == -1:
+                return None
+            return usage[idx + len(option_string)]
+
+    @classmethod
+    def _get_option_group(cls, fmt, action):
+        """
+        Extract group of option properties from specified action
+
+        :param fmt: HelpFormatter to use
+        :param action: source Action
+        :return: list of option properties
+        """
+        result = []
+        if not action.option_strings:
+            # positional option
+            metavar, = fmt._metavar_formatter(action, action.dest)(1)
+            args = fmt._format_args(action, action.dest)
+            optional = False
+            if args[0] == '[' and args[-1] == ']':
+                args = args[1:-1]
+                optional = True
+            result.append(dict(name=metavar, synopsis=args, optional=optional))
+        else:
+            if action.nargs == 0:
+                # option without arguments
+                for option_string in action.option_strings:
+                    result.append(dict(name=option_string, synopsis=option_string))
+            else:
+                # option with arguments
+                args = fmt._format_args(action, action.dest.upper())
+                delim = cls._get_delimiter(fmt, action)
+                for option_string in action.option_strings:
+                    result.append(dict(name=option_string, args=delim+args, synopsis=option_string+delim+args))
+        return result
+
+    def _build_option_description(self, fmt, action, custom_content):
+        """
+        Build description of program option
+
+        :param fmt: HelpFormatter to use
+        :param action: source Action
+        :param custom_content: custom content for option
+        :return: node forming option description
+        """
+        action.help = self._decorate_references(action.help)
+        help = fmt._expand_help(action)
+        result = nodes.container()
+        self.state.nested_parse(StringList([help]), 0, result)
+        if custom_content:
+            if custom_content['action'] == 'append':
+                result.extend(custom_content['content'].children)
+            elif custom_content['action'] == 'prepend':
+                result[0:0] = custom_content['content'].children
+            elif custom_content['action'] == 'replace':
+                result[:] = custom_content['content']
+        return result
+
+    def _build_option_index(self, progname, ids, names, synopses):
+        """
+        Build index for program option and register it in the environment
+
+        :param progname: program name
+        :param ids: list of all option ids
+        :param names: list of all option names
+        :param synopses: list of all option synopses
+        :return: index node
+        """
+        env = self.state.document.settings.env
+        result = addnodes.index(entries=[])
+        for id, name, synopsis in zip(ids, names, synopses):
+            env.domaindata['std']['progoptions'][progname, name] = env.docname, id
+            if synopsis != name:
+                env.domaindata['std']['progoptions'][progname, synopsis] = env.docname, id
+            pair = '{} command line option; {}'.format(progname, ', '.join(synopses))
+            result['entries'].append(('pair', pair, id, '', None))
+        return result
+
+    def _build_option(self, parser, action, custom_content):
+        """
+        Build single program option
+
+        :param parser: pre-configured ArgumentParser instance
+        :param action: source Action
+        :param custom_content: custom content for options
+        :return: node forming program option
+        """
+        def get_id(progname, name):
+            id = 'cmdoption-{}'.format(progname)
+            if not name.startswith('-'):
+                id += '-arg-'
+            id += name
+            return id
+        fmt = parser._get_formatter()
+        result = nodes.container()
+        signature = addnodes.desc_signature(ids=[], allnames=[], first=False)
+        self.state.document.note_explicit_target(signature)
+        description = self._build_option_description(fmt, action, custom_content)
+        content = addnodes.desc_content('', description)
+        result.append(addnodes.desc('', signature, content, objtype='option'))
+        progname = self._get_program_name(parser)
+        synopses = []
+        for option in self._get_option_group(fmt, action):
+            signature['ids'].append(get_id(progname, option['name']))
+            signature['allnames'].append(option['name'])
+            signature.append(addnodes.desc_name(text=option['name']))
+            if 'args' in option:
+                signature.append(addnodes.desc_addname(text=option['args']))
+            signature.append(addnodes.desc_addname(text=', '))
+            synopses.append(option['synopsis'])
+        signature.pop()
+        index = self._build_option_index(progname, signature['ids'], signature['allnames'], synopses)
+        result.append(index)
+        return result
+
+    def _build_program_synopsis(self, parser):
+        """
+        Build program synopsis
+
+        :param parser: pre-configured ArgumentParser instance
+        :return: node forming program synopsis
+        """
+        fmt = parser._get_formatter()
+        groups = []
+        for action in parser._get_optional_actions() + parser._get_positional_actions():
+            if action.help is SUPPRESS:
+                continue
+            in_group = False
+            for group in parser._mutually_exclusive_groups:
+                if action in group._group_actions:
+                    in_group = True
+                    if action == group._group_actions[0]:
+                        groups.append(dict(actions=group._group_actions, required=group.required))
+            if not in_group:
+                groups.append(dict(actions=[action], required=action.required))
+        synopsis = ['\\ :program:`{}`\\ '.format(parser.prog)]
+        for group in groups:
+            usages = []
+            for action in group['actions']:
+                option = self._get_option_group(fmt, action)[0]
+                if option.get('optional') and len(group['actions']) == 1:
+                    group['required'] = False
+                usage = '\\ :option:`{}`\\ '.format(option['synopsis'])
+                usages.append(usage)
+            if not group['required']:
+                synopsis.append('[{}]'.format(' | '.join(usages)))
+            elif len(group['actions']) > 1:
+                synopsis.append('({})'.format(' | '.join(usages)))
+            else:
+                synopsis.append('{}'.format(usages[0]))
+        synopsis = self._format_synopsis(synopsis)
+        paragraph = nodes.paragraph()
+        self.state.nested_parse(StringList(synopsis), 0, paragraph)
+        return nodes.container('', paragraph)
+
+    def _build_program_description(self, parser):
+        """
+        Build program description
+
+        :param parser: pre-configured ArgumentParser instance
+        :return: node forming program description
+        """
+        description = self._decorate_references(parser.description)
+        description = description % dict(prog=parser.prog)
+        result = nodes.container()
+        self.state.nested_parse(StringList([description]), 0, result)
+        return result
+
+    def _build_program_options(self, parser, custom_content):
+        """
+        Build list of program options
+
+        :param parser: pre-configured ArgumentParser instance
+        :param custom_content: custom content for options
+        :return: node forming program options
+        """
+        result = nodes.container()
+        if self.ignore_option_groups:
+            actions = parser._get_positional_actions() + parser._get_optional_actions()
+            actions = [a for a in actions if a.help is not SUPPRESS]
+            for action in actions:
+                cc = [v for k, v in six.iteritems(custom_content) if k in action.option_strings]
+                result.append(self._build_option(parser, action, cc[0] if cc else None))
+        else:
+            for group in parser._action_groups:
+                actions = [a for a in group._group_actions if a.help is not SUPPRESS]
+                if actions:
+                    title = nodes.title(text=group.title.capitalize())
+                    options = nodes.container()
+                    for action in actions:
+                        cc = [v for k, v in six.iteritems(custom_content) if k in action.option_strings]
+                        options.append(self._build_option(parser, action, cc[0] if cc else None))
+                    result.append(nodes.section('', title, options, ids=[group.title.lower()]))
+        return result
+
+    def _get_custom_content(self):
+        """Load custom content for each section and for program options"""
+        content = nodes.container()
+        self.state.nested_parse(self.content, self.content_offset, content)
+        sections = {}
+        options = {}
+        if len(content) and isinstance(content[0], nodes.definition_list):
+            for item in content[0]:
+                term = None
+                classifiers = []
+                definition = None
+                for element in item.children:
+                    if isinstance(element, nodes.term):
+                        if element.children:
+                            term = str(element[0]).lower()
+                    elif isinstance(element, nodes.classifier):
+                        if element.children:
+                            classifiers.append(str(element[0]).lower())
+                    elif isinstance(element, nodes.definition):
+                        if element.children:
+                            definition = nodes.container('', *element.children)
+                if term in ['synopsis', 'description', 'options', 'option']:
+                    action = [c[1:] for c in classifiers if c and c[0] == '@']
+                    action = action[0] if action else 'append'
+                    opts = [c for c in classifiers if c and c[0] != '@']
+                    if definition:
+                        if term != 'option':
+                            sections[term] = dict(action=action, content=definition)
+                        else:
+                            for opt in opts:
+                                options[opt] = dict(action=action, content=definition)
+        return sections, options
+
+    def _construct_main_sections(self, parser):
+        """
+        Construct Synopsis, Description and Options sections
+
+        :param parser: pre-configured ArgumentParser instance
+        :return: list of section nodes
+        """
+        cc_sections, cc_options = self._get_custom_content()
+        result = []
+        for section in ['synopsis', 'description', 'options']:
+            method = '_build_program_{}'.format(section)
+            method = getattr(self, method)
+            args = [parser]
+            if section == 'options':
+                args.append(cc_options)
+            title = nodes.title(text=section.upper())
+            content = method(*args)
+            if section in cc_sections:
+                cc = cc_sections[section]
+                if cc['action'] == 'append':
+                    content.extend(cc['content'].children)
+                elif cc['action'] == 'prepend':
+                    content[0:0] = cc['content'].children
+                elif cc['action'] == 'replace':
+                    content[:] = cc['content']
+            else:
+                # append empty paragraph to ensure separation from consecutive section
+                content.append(nodes.paragraph(text=''))
+            result.append(nodes.section('', title, content, ids=[section.lower()]))
+        return result
+
+    def _get_parser(self):
+        """Get parser instance"""
+        function = self.options.get('function')
+        module = self.options.get('module')
+        # import module and get instance of function to call
+        parts = function.split('.')
+        try:
+            mod = __import__(module, globals(), locals(), [parts[0]])
+        except ImportError as e:
+            raise AutoArgsError('Problem importing module: {}'.format(str(e)))
+        try:
+            obj = getattr(mod, parts[0])
+            for sub in parts[1:]:
+                obj = getattr(obj, sub)
+        except AttributeError as e:
+            raise AutoArgsError('Problem accessing function: {}'.format(str(e)))
+        # instantiate object
+        try:
+            parser = obj()
+        except TypeError as e:
+            raise AutoArgsError('Problem calling function: {}'.format(str(e)))
+        if not isinstance(parser, ArgumentParser):
+            raise AutoArgsError('Function must return instance of argparse.ArgumentParser or derived class')
+        return parser
+
+    def run(self):
+        """Run the directive"""
+        parser = self._get_parser()
+        parser.prog = self.options.get('program_name', parser.prog)
+        env = self.state.document.settings.env
+        env.ref_context['std:program'] = self._get_program_name(parser)
+        self.synopsis_max_width = self.options.get('synopsis_max_width', 80)
+        self.ignore_option_groups = 'ignore_option_groups' in self.options
+        return self._construct_main_sections(parser)
+
+
+def setup(app):
+    app.add_directive('autoargs', AutoArgsDirective)
+    return dict(version='0.1')

--- a/docs/baseoutput.rst
+++ b/docs/baseoutput.rst
@@ -1,6 +1,0 @@
-Base output module
-===================
-
-.. automodule:: rebasehelper.base_output
-   :members:
-   :undoc-members:

--- a/docs/brief-intro.txt
+++ b/docs/brief-intro.txt
@@ -1,1 +1,0 @@
-Rebase-helper is tools has aim to help you with rebasing your packages.

--- a/docs/buildloganalyzer.rst
+++ b/docs/buildloganalyzer.rst
@@ -1,5 +1,5 @@
 Build log analyzer module
-===================
+=========================
 
 .. automodule:: rebasehelper.build_log_analyzer
    :members:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,5 +1,5 @@
 CLI module
-===================
+==========
 
 .. automodule:: rebasehelper.cli
    :members:

--- a/docs/clsoverview.rst
+++ b/docs/clsoverview.rst
@@ -1,13 +1,14 @@
-Module Overview
+Module overview
 ===============
+
 .. toctree::
    :maxdepth: 2
 
+   cli
    application
    patchhelper
    utils
    archive
-   baseoutput
    buildhelper
    buildloganalyzer
    exceptions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'rebase-helper'
-copyright = u'2016, Petr Hracek, Tomas Hozza'
+copyright = u'2014-2016, Red Hat'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('.'))
 rebase_helper_dir = os.path.abspath('..')
 sys.path.insert(0, rebase_helper_dir)
 
@@ -49,6 +49,8 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'autoargs',
+    'custom_man_builder',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Rebase-Helper'
+project = u'rebase-helper'
 copyright = u'2016, Petr Hracek, Tomas Hozza'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -145,7 +145,7 @@ html_theme_path = [] if on_rtd else [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -189,7 +189,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'RebaseHelperdoc'
+htmlhelp_basename = 'RebaseHelperDoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -209,8 +209,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'RebaseHelper.tex', u'Rebase Helper Documentation',
-   u'Petr Hracek, Tomas Hozza', 'manual'),
+  (master_doc, 'RebaseHelper.tex', u'Rebase Helper Documentation',
+   u'Petr Hracek \\and Tomas Hozza', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -239,8 +239,9 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'RebaseHelper', u'Rebase Helper Documentation',
-     [u'Petr Hracek, Tomas Hozza'], 1)
+    ('manpage', 'rebase-helper',
+     u'helps you to rebase package to the latest upstream version',
+     [u'Petr Hracek', u'Tomas Hozza'], 1),
 ]
 
 # If true, show URL addresses after external links.
@@ -253,8 +254,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'RebaseHelper', u'Rebase Helper Documentation',
-   u'Petr Hracek, Tomas Hozza', 'RebaseHelper', 'One line description of project.',
+  (master_doc, 'RebaseHelper', u'Rebase Helper Documentation',
+   u'Petr Hracek@*Tomas Hozza', 'RebaseHelper', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/custom_man_builder.py
+++ b/docs/custom_man_builder.py
@@ -1,0 +1,100 @@
+import re
+
+from docutils import nodes
+from sphinx.writers.manpage import ManualPageTranslator
+from sphinx.builders.manpage import ManualPageBuilder
+
+
+class CustomManPageTranslator(ManualPageTranslator):
+    """
+    Manual page translator which properly formats option text roles
+    and option directives
+    """
+    def __init__(self, builder, *args, **kwds):
+        ManualPageTranslator.__init__(self, builder, *args, **kwds)
+        self.option_context = []
+
+    @staticmethod
+    def _format_option(text):
+        """
+        Format single option, make option strings bold and option arguments italic
+        """
+        def get_font(token):
+            # option strings start with "-"
+            return 'B' if token['text'].startswith('-') else 'I'
+        # find all tokens to be decorated, excluding "..."
+        matches = list(re.finditer(r'[^\s\[\]{}=,|]+', text))
+        tokens = [dict(text=m.group(0), span=m.span()) for m in matches if m.group(0) != '...']
+        for t in reversed(tokens):
+            text = text[: t['span'][1]] + '\\fP' + text[t['span'][1]:]
+            text = text[: t['span'][0]] + '\\f{}'.format(get_font(t)) + text[t['span'][0]:]
+        return text
+
+    def visit_desc_signature(self, node):
+        self.visit_definition_list_item(node)
+        self.body.append('\n')
+
+    def depart_desc_signature(self, node):
+        # format option text formed by preceding desc_names and desc_addnames
+        if self.option_context:
+            self.body.append(self._format_option(''.join(self.option_context)))
+            del self.option_context[:]
+        self.body.append('\n')
+
+    def visit_desc_name(self, node):
+        # save text for later
+        self.option_context.append(node.astext())
+        raise nodes.SkipNode
+
+    def visit_desc_addname(self, node):
+        text = node.astext()
+        # desc_addname node containing only "," is taken as option separator
+        if text.strip() == ',':
+            # format option text formed by preceding desc_names and desc_addnames
+            if self.option_context:
+                self.body.append(self._format_option(''.join(self.option_context)))
+                del self.option_context[:]
+        else:
+            # save text for later
+            self.option_context.append(text)
+            raise nodes.SkipNode
+
+    def visit_reference(self, node):
+        if node.children and isinstance(node[0], nodes.literal):
+            if 'std-option' in node[0].get('classes', ''):
+                # prevent ignoring nested option node
+                raise nodes.SkipDeparture
+        ManualPageTranslator.visit_reference(self, node)
+
+    def visit_literal(self, node):
+        if 'std-option' in node.get('classes', ''):
+            # format option text
+            self.body.append(self._format_option(node.astext()))
+            raise nodes.SkipNode
+        else:
+            self.visit_emphasis(node)
+
+    def depart_literal(self, node):
+        self.depart_emphasis(node)
+
+    def visit_manpage(self, node):
+        text = node.astext()
+        # parentheses and section numbers inside them shouldn't be bold
+        text = re.sub(r'(\(\d*\))', r'\\fR\1\\fP', text)
+        self.body.append('\\fB{}\\fP'.format(text))
+        raise nodes.SkipNode
+
+
+class CustomManPageBuilder(ManualPageBuilder):
+    """Manual page builder which uses CustomManualPageTranslator"""
+    name = 'custom-man'
+
+    def init(self):
+        ManualPageBuilder.init(self)
+        # use custom translator
+        self.translator_class = CustomManPageTranslator
+
+
+def setup(app):
+    app.add_builder(CustomManPageBuilder)
+    return dict(version='0.1')

--- a/docs/description.rst
+++ b/docs/description.rst
@@ -1,0 +1,10 @@
+.. program description
+
+:program:`rebase-helper` is a tool which helps package maintainers
+to rebase their packages to latest upstream versions.
+
+It should be executed from a directory containing spec file, sources
+and patches (usually cloned dist-git repository).
+
+The new version is specified by :option:`SOURCES` argument, which can be
+either version number or filename of the new source archive.

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,6 +1,6 @@
 Exception module
-===================
+================
 
-.. automodule:: rebasehelper.exception
+.. automodule:: rebasehelper.exceptions
    :members:
    :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,5 @@
-.. RebaseHelper documentation master file, created by
-   sphinx-quickstart on Tue Apr 21 13:42:00 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to RebaseHelper's documentation!
-========================================
+Welcome to rebase-helper's documentation!
+=========================================
 
 Contents:
 
@@ -14,8 +9,6 @@ Contents:
    overview
    clsoverview
    upstreammonitoring
-
-
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Contents:
    :maxdepth: 3
 
    overview
+   usage
    clsoverview
    upstreammonitoring
 

--- a/docs/logger.rst
+++ b/docs/logger.rst
@@ -1,5 +1,5 @@
 Logger module
-===================
+=============
 
 .. automodule:: rebasehelper.logger
    :members:

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1,0 +1,39 @@
+:orphan: .. do not include this document into toctree
+
+rebase-helper man page
+======================
+
+.. autoargs::
+   :function: CLI.build_parser
+   :module: rebasehelper.cli
+   :program_name: rebase-helper
+   :ignore_option_groups:
+
+   DESCRIPTION : @replace
+      .. include:: description.rst
+
+   OPTION : -h : @replace
+      show help message and exit
+
+EXIT STATUS
+-----------
+
+This program returns 0 if successful, or non-zero if there was an error.
+
+.. TODO: list of known issues
+   NOTES
+   -----
+
+.. TODO: example of basic rebase
+   EXAMPLE
+   -------
+
+SEE ALSO
+--------
+
+:manpage:`rpmbuild(8)`,
+:manpage:`mock(1)`,
+:manpage:`rpmdiff(1)`,
+:manpage:`pkgdiff(1)`,
+:manpage:`abipkgdiff(1)`,
+:manpage:`csmock(1)`

--- a/docs/outputtool.rst
+++ b/docs/outputtool.rst
@@ -1,5 +1,5 @@
 Ouptut tool module
-===================
+==================
 
 .. automodule:: rebasehelper.output_tool
    :members:

--- a/docs/specfile.rst
+++ b/docs/specfile.rst
@@ -1,5 +1,5 @@
 Specfile module
-===================
+===============
 
 .. automodule:: rebasehelper.specfile
    :members:

--- a/docs/upstreammonitoring.rst
+++ b/docs/upstreammonitoring.rst
@@ -1,5 +1,5 @@
 How to use the rebase-helper for upstream monitoring systems
-========================================================
+============================================================
 
 The page describes the integration of the rebase-helper into upstream monitoring systems.
 
@@ -17,7 +17,7 @@ Install a rebase-helper package
 Nowadays only koji build systems are used as a support for upstream monitoring systems.
 
 Patch the new sources and run a koji scratch build
----------------------------------------------------
+--------------------------------------------------
 
 - **Python API usage**
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,15 @@
+Usage
+=====
+
+.. autoargs::
+   :function: CLI.build_parser
+   :module: rebasehelper.cli
+   :program_name: rebase-helper
+   :synopsis_max_width: 72
+
+   DESCRIPTION : @replace
+      .. include:: description.rst
+
+   OPTION : -h : @replace
+      show help message and exit
+

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -77,68 +77,64 @@ class CustomArgumentParser(argparse.ArgumentParser):
 class CLI(object):
     """ Class for processing data from commandline """
 
-    def __init__(self, args=None):
-        """parse arguments"""
-        self.parser = CustomArgumentParser(description=PROGRAM_DESCRIPTION,
-                                           formatter_class=CustomHelpFormatter)
-        self.add_args()
-        self.args = self.parser.parse_args(args)
-
-    def add_args(self):
-        self.parser.add_argument(
+    @staticmethod
+    def build_parser():
+        parser = CustomArgumentParser(description=PROGRAM_DESCRIPTION,
+                                      formatter_class=CustomHelpFormatter)
+        parser.add_argument(
             "-v",
             "--verbose",
             default=False,
             action="store_true",
             help="be more verbose (recommended)"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "-p",
             "--patch-only",
             default=False,
             action="store_true",
             help="only apply patches"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "-b",
             "--build-only",
             default=False,
             action="store_true",
             help="only build SRPM and RPMs"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--buildtool",
             choices=Builder.get_supported_tools(),
             default=Builder.get_default_tool(),
             help="build tool to use, defaults to %(default)s"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--pkgcomparetool",
             choices=checkers_runner.get_supported_tools(),
             default=checkers_runner.get_default_tools(),
             type=lambda s: s.split(','),
             help="set of tools to use for package comparison, defaults to %(default)s"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--outputtool",
             choices=OutputTool.get_supported_tools(),
             default=OutputTool.get_default_tool(),
             help="tool to use for formatting rebase output, defaults to %(default)s"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "-w",
             "--keep-workspace",
             default=False,
             action="store_true",
             help="do not remove workspace directory after finishing"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--not-download-sources",
             default=False,
             action="store_true",
             help="do not download sources"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "-c",
             "--continue",
             default=False,
@@ -146,19 +142,19 @@ class CLI(object):
             dest='cont',
             help="continue previously interrupted rebase"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "sources",
             metavar='SOURCES',
             help="new upstream sources"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--non-interactive",
             default=False,
             action="store_true",
             dest='non_interactive',
             help="do not interact with user"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--comparepkgs-only",
             default=False,
             dest="comparepkgs",
@@ -166,43 +162,49 @@ class CLI(object):
             help="compare already built packages, %(metavar)s must be a directory "
                  "with the following structure: <dir_name>/{old,new}/RPM"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--builds-nowait",
             default=False,
             action="store_true",
             help="do not wait for koji or copr builds to finish"
         )
         # deprecated argument, kept for backward compatibility
-        self.parser.add_argument(
+        parser.add_argument(
             "--fedpkg-build-tasks",
             dest="fedpkg_build_tasks",
             type=lambda s: s.split(','),
             help=argparse.SUPPRESS
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--build-tasks",
             dest="build_tasks",
             metavar="OLD_TASK,NEW_TASK",
             type=lambda s: s.split(','),
             help="comma-separated koji or copr task ids"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--results-dir",
             help="directory where rebase-helper output will be stored"
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--build-retries",
             default=2,
             help="number of retries of a failed build, defaults to %(default)d",
             type=int
         )
-        self.parser.add_argument(
+        parser.add_argument(
             "--builder-options",
             default=None,
             metavar="BUILDER_OPTIONS",
             help="enable arbitrary local builder option(s), enclose %(metavar)s in quotes "
                  "and note that = before it is mandatory"
         )
+        return parser
+
+    def __init__(self, args=None):
+        """parse arguments"""
+        self.parser = CLI.build_parser()
+        self.args = self.parser.parse_args(args)
 
     def __getattr__(self, name):
         try:

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -678,8 +678,8 @@ class SpecFile(object):
         Method splits version string into version and possibly extra string as 'rc1' or 'b1', ...
 
         :param version_string: version string such as '1.1.1' or '1.2.3b1', ...
-        :return: tuple of strings with (extracted version, extra version, separator) or (None, None, None) if extraction
-        failed
+        :return: tuple of strings with (extracted version, extra version, separator) or (None, None, None)
+                 if extraction failed
         """
         version_split_regex_str = r'([0-9]+[.0-9]*)([_-]?)(\w*)'
         version_split_regex = re.compile(version_split_regex_str)

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -222,8 +222,8 @@ class DownloadHelper(object):
         :type download_total: int or float
         :param downloaded: already downloaded size of the file
         :type downloaded: int or float
-        :param start_time: time in seconds since the epoch from the point when the download started. This is used to
-        calculate the remaining time of the download.
+        :param start_time: time in seconds since the epoch from the point when the download started.
+                           This is used to calculate the remaining time of the download.
         :type start_time: float
         :return: None
         """


### PR DESCRIPTION
This PR adds posibility to automatically generate program documentation from ArgumentParser instance. It introduces Sphinx extension `autoargs`, which is similar to [sphinx-argparse](https://github.com/ribozz/sphinx-argparse), but actually quite different. There is also custom manpage builder `custom-man`, which is needed because default Sphinx manpage builder is not very usable when you want the same source for both html and man.

You can see html output on [readthedocs](http://rebase-helper.readthedocs.io/en/documentation-changes/usage.html).

To see the manpage, run the following in `docs` subdir:
```
make man
man -l _build/man/rebase-helper.1
```

This resolves issue #187.