### PR TITLE
Install python3-tox on Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:
   # don't start any services (mailny not the default ones)
   services:
   script:
-    - dnf -y install python2 python2-devel python3 python3-devel rpm-python rpm-python3 python-tox python-pip python3-pip python-setuptools python3-setuptools gcc redhat-rpm-config libxml2-devel libxslt-devel xz-devel git
+    - dnf -y install python2 python2-devel python3 python3-devel rpm-python rpm-python3 python-tox python3-tox python-pip python3-pip python-setuptools python3-setuptools gcc redhat-rpm-config libxml2-devel libxslt-devel xz-devel git
     #- pip install tox setuptools
     - tox --recreate
 


### PR DESCRIPTION
In Fedora rawhide tox binary moved from python-tox to python3-tox.
Install python3-tox package since doing so won't do any harm on
F23 or F24 and it will prevent test failure on rawhide.