### PR TITLE
Handle %setup dirname argument containing slashes

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -335,15 +335,18 @@ class Application(object):
         """Function extracts a given Archive and returns a full dirname to sources"""
         Application.extract_archive(archive_path, destination)
 
-        try:
-            sources_dir = os.listdir(destination)[0]
-        except IndexError:
-            raise RebaseHelperError('Extraction of sources failed!')
+        files = os.listdir(destination)
 
-        if os.path.isdir(os.path.join(destination, sources_dir)):
-            return os.path.join(destination, sources_dir)
-        else:
-            return destination
+        if not files:
+            raise RebaseHelperError('Extraction of sources failed!')
+        # if there is only one directory, we can assume it's top-level directory
+        elif len(files) == 1:
+            sources_dir = os.path.join(destination, files[0])
+            if os.path.isdir(sources_dir):
+                return sources_dir
+
+        # archive without top-level directory
+        return destination
 
     def prepare_sources(self):
         """

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -354,17 +354,29 @@ class Application(object):
 
         :return: 
         """
-        old_dir = Application.extract_sources(self.old_sources,
-                                              os.path.join(self.execution_dir, settings.OLD_SOURCES_DIR))
-        new_dir = Application.extract_sources(self.new_sources,
-                                              os.path.join(self.execution_dir, settings.NEW_SOURCES_DIR))
 
-        # determine top-level directory in new_sources archive
-        toplevel_dir = os.path.relpath(new_dir,
-                                       os.path.join(self.execution_dir, settings.NEW_SOURCES_DIR))
+        old_sources_dir = os.path.join(self.execution_dir, settings.OLD_SOURCES_DIR)
+        new_sources_dir = os.path.join(self.execution_dir, settings.NEW_SOURCES_DIR)
 
-        if toplevel_dir != '.':
-            self.rebase_spec_file.update_setup_dirname(toplevel_dir)
+        old_dir = Application.extract_sources(self.old_sources, old_sources_dir)
+        new_dir = Application.extract_sources(self.new_sources, new_sources_dir)
+
+        old_tld = os.path.relpath(old_dir, old_sources_dir)
+        new_tld = os.path.relpath(new_dir, new_sources_dir)
+
+        dirname = self.spec_file.get_setup_dirname()
+
+        if dirname and os.sep in dirname:
+            dirs = os.path.split(dirname)
+            if old_tld == dirs[0]:
+                old_dir = os.path.join(old_dir, *dirs[1:])
+            if new_tld == dirs[0]:
+                new_dir = os.path.join(new_dir, *dirs[1:])
+
+        new_dirname = os.path.relpath(new_dir, new_sources_dir)
+
+        if new_dirname != '.':
+            self.rebase_spec_file.update_setup_dirname(new_dirname)
 
         # extract rest of source archives to correct paths
         rest_sources = [self.old_rest_sources, self.new_rest_sources]

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -1148,7 +1148,7 @@ class SpecFile(object):
                     args.append(new_dirname)
 
                     self.spec_content[index] = '#{0}'.format(line)
-                    self.spec_content.insert(index + 1, ' '.join(args))
+                    self.spec_content.insert(index + 1, ' '.join(args) + '\n')
                     self.save()
 
     def find_archive_target_in_prep(self, archive):

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -435,11 +435,13 @@ class TestSpecFile(BaseTest):
 
         self.SPEC_FILE_OBJECT.update_setup_dirname('test-1.0.2rc1')
         prep = self.SPEC_FILE_OBJECT.get_spec_section('%prep')
-        assert '%setup -q -a 5 -n %{name}-%{REBASE_VER}' in prep
+        setup = [l for l in prep if l.startswith('%setup')][0]
+        assert '-n %{name}-%{REBASE_VER}' in setup
 
         self.SPEC_FILE_OBJECT.update_setup_dirname('test-1.0.2-rc1')
         prep = self.SPEC_FILE_OBJECT.get_spec_section('%prep')
-        assert '%setup -q -a 5 -n %{name}-%{version}-%{REBASE_EXTRA_VER}' in prep
+        setup = [l for l in prep if l.startswith('%setup')][0]
+        assert '-n %{name}-%{version}-%{REBASE_EXTRA_VER}' in setup
 
     def test_find_archive_target_in_prep(self):
         target = self.SPEC_FILE_OBJECT.find_archive_target_in_prep('documentation.tar.xz')


### PR DESCRIPTION
In case `%setup` macro is specified e.g. like this:

`%setup -q -n screen/src`

it means that when rpmbuild is running `%prep`, sources are extracted
to `src` subdirectory.

Switch to such subdirectory after extracting sources, to prevent
patching failures. Also preserve such subdirectories when updating
`%setup` dirname argument.

Add missing newline after updating `%setup` macro.

This PR resolves issue #235.
