### PR TITLE
Do not fail when size of downloaded file is not known

### DIFF
--- a/rebasehelper/tests/test_utils.py
+++ b/rebasehelper/tests/test_utils.py
@@ -189,7 +189,7 @@ class TestDownloadHelper(BaseTest):
 
     def test_download_existing_file_HTTP(self):
         """
-        Test downloading exiting file via HTTP.
+        Test downloading existing file via HTTP.
         """
         KNOWN_URL = 'http://fedoraproject.org/static/hotspot.txt'
         LOCAL_FILE = os.path.basename(KNOWN_URL)
@@ -202,7 +202,7 @@ class TestDownloadHelper(BaseTest):
 
     def test_download_existing_file_HTTPS(self):
         """
-        Test downloading exiting file via HTTPS.
+        Test downloading existing file via HTTPS.
         """
         KNOWN_URL = 'https://ftp.isc.org/isc/bind9/9.10.4-P1/srcid'
         LOCAL_FILE = os.path.basename(KNOWN_URL)
@@ -215,7 +215,7 @@ class TestDownloadHelper(BaseTest):
 
     def test_download_existing_file_FTP(self):
         """
-        Test downloading exiting file via FTP
+        Test downloading existing file via FTP
         """
         KNOWN_URL = 'ftp://ftp.isc.org/isc/bind9/9.10.4-P1/srcid'
         LOCAL_FILE = os.path.basename(KNOWN_URL)
@@ -228,7 +228,7 @@ class TestDownloadHelper(BaseTest):
 
     def test_download_non_existing_file_HTTPS(self):
         """
-        Test downloading NON exiting file via HTTPS
+        Test downloading NON existing file via HTTPS
         :return:
         """
         KNOWN_URL = 'https://ftp.isc.org/isc/bind9/9.10.3-P5/srcid'
@@ -241,7 +241,7 @@ class TestDownloadHelper(BaseTest):
 
     def test_download_non_existing_file_FTP(self):
         """
-        Test downloading NON exiting file via FTP
+        Test downloading NON existing file via FTP
         :return:
         """
         KNOWN_URL = 'ftp://ftp.isc.org/isc/bind9/9.10.3-P5/srcid'

--- a/rebasehelper/tests/test_utils.py
+++ b/rebasehelper/tests/test_utils.py
@@ -175,7 +175,7 @@ class TestDownloadHelper(BaseTest):
         monkeypatch.setattr('sys.stdout', buffer)
         monkeypatch.setattr('time.time', lambda: 10.0)
         DownloadHelper.progress(100, 25, 0.0)
-        assert buffer.getvalue() == ' 25% (00:00:30 remaining)\r'
+        assert buffer.getvalue() == '\r 25%[=======>                      ]    25.00   eta 00:00:30 '
 
     def test_progress_float(self, monkeypatch):
         """
@@ -185,7 +185,7 @@ class TestDownloadHelper(BaseTest):
         monkeypatch.setattr('sys.stdout', buffer)
         monkeypatch.setattr('time.time', lambda: 10.0)
         DownloadHelper.progress(100.0, 25.0, 0.0)
-        assert buffer.getvalue() == ' 25% (00:00:30 remaining)\r'
+        assert buffer.getvalue() == '\r 25%[=======>                      ]    25.00   eta 00:00:30 '
 
     def test_download_existing_file_HTTP(self):
         """


### PR DESCRIPTION
Introduce wget-like download progress bar, which can show some statistics also in case the size of downloaded file is not known.

This PR resolves issue #193.

I thought this should be resolved rather sooner than later, since many rebases initiated by upstream monitoring are failing because of this.

@phracek, @thozza: Can you review this PR when you have time?