### PR TITLE
Propagate logs from failed SRPM build to results store

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -490,6 +490,8 @@ class Application(object):
                     break
 
                 except SourcePackageBuildError:
+                    build_dict.update(builder.get_logs())
+                    results_store.set_build_data(version, build_dict)
                     #  always fail for original version
                     if version == 'old':
                         raise RebaseHelperError('Creating old SRPM package failed.')

--- a/rebasehelper/build_helper.py
+++ b/rebasehelper/build_helper.py
@@ -261,6 +261,7 @@ class BuildToolBase(object):
             srpm = cls._do_build_srpm(tmp_spec, tmp_dir, tmp_results_dir)
 
         if srpm is None:
+            cls.logs = [l for l in PathHelper.find_all_files(srpm_results_dir, '*.log')]
             raise SourcePackageBuildError("Building SRPM failed!")
         else:
             logger.info("Building SRPM finished successfully")


### PR DESCRIPTION
This is necessary for the-new-hotness to be able to pick them up and attach them to bugzilla.