### PR TITLE
Add koji to the list of mocked modules for sphinx.ext.autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -276,4 +276,4 @@ texinfo_documents = [
 # This value contains a list of modules to be mocked up. This is useful
 # when some external dependencies are not met at build time and break
 # the building process.
-autodoc_mock_imports = ['backports.lzma', 'rpm']
+autodoc_mock_imports = ['backports.lzma', 'rpm', 'koji']


### PR DESCRIPTION
Latest koji reads `rpm.__version_info__`, but doing so fails when rpm module is mocked.

Mock also koji module to prevent the failure.