### PR TITLE
Koji compatibility changes

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -448,14 +448,12 @@ class Application(object):
                         build_dict.update(builder.build(spec, sources, patches, results_dir, **build_dict))
                     if not self.conf.builds_nowait:
                         if self.conf.buildtool == KojiBuildTool.CMD:
-                            while True:
+                            while not build_dict['rpm']:
                                 kh = KojiHelper()
                                 build_dict['rpm'], build_dict['logs'] = kh.get_koji_tasks(
                                     build_dict['koji_task_id'],
                                     results_dir
                                 )
-                                if build_dict['rpm']:
-                                    break
                     else:
                         if self.conf.build_tasks:
                             if self.conf.buildtool == KojiBuildTool.CMD:

--- a/rebasehelper/build_helper.py
+++ b/rebasehelper/build_helper.py
@@ -510,7 +510,9 @@ class KojiBuildTool(BuildToolBase):
             if task_dict[key] == koji.TASK_STATES['FAILED']:
                 package_failed = True
             task_list.append(key)
-        rpms, logs = cls.koji_helper.download_scratch_build(task_list, os.path.dirname(source).replace('SRPM', 'RPM'))
+        rpms, logs = cls.koji_helper.download_scratch_build(session,
+                                                            task_list,
+                                                            os.path.dirname(source).replace('SRPM', 'RPM'))
         if package_failed:
             weburl = '%s/taskinfo?taskID=%i' % (cls.weburl, task_list[0])
             logger.info('RPM build failed %s', weburl)

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -1076,8 +1076,7 @@ class KojiHelper(object):
         return rh_tasks
 
     @classmethod
-    def download_scratch_build(cls, task_list, dir_name):
-        session = cls.session_maker()
+    def download_scratch_build(cls, session, task_list, dir_name):
         rpms = []
         logs = []
         for task_id in task_list:
@@ -1096,7 +1095,6 @@ class KojiHelper(object):
                         rpms.append(downloaded_file)
                     if filename.endswith('.log'):
                         logs.append(downloaded_file)
-        session.logout()
         return rpms, logs
 
     @classmethod


### PR DESCRIPTION
Starting with `koji-1.11.0`, `koji` buildtool is not working anymore.
Make necessary changes to get it working again.