### PR TITLE
Test fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,20 +3,20 @@ stages:
 
 .test_template: &test_definition
   stage: test
-  # don't start any services (mailny not the default ones)
+  # don't start any services (mainly not the default ones)
   services:
   script:
     - dnf -y install python2 python2-devel python3 python3-devel rpm-python rpm-python3 python-tox python3-tox python-pip python3-pip python-setuptools python3-setuptools gcc redhat-rpm-config libxml2-devel libxslt-devel xz-devel git
     #- pip install tox setuptools
     - tox --recreate
 
-test:f23:
-  <<: *test_definition
-  image: fedora:23
-
 test:f24:
   <<: *test_definition
   image: fedora:24
+
+test:f25:
+  <<: *test_definition
+  image: fedora:25
 
 test:rawhide:
   <<: *test_definition

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,5 @@ pytest-cov
 pytest
 pytest-pylint
 pylint>=1.4.5
+# use fixed version of astroid, see: https://github.com/PyCQA/astroid/pull/422
+git+https://github.com/PyCQA/astroid.git@6329346e5836e553ab8f96f9d540e907a5d5efdb#egg=astroid

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps=
     -rtest-requirements.txt
 
 [testenv:travis]
+setenv=LANG=C.UTF-8
 passenv=TRAVIS
 commands={[test-base]commands}
 sitepackages={[test-base]sitepackages}
@@ -17,6 +18,7 @@ deps=
     https://raw.githubusercontent.com/nforro/rpm-bundle/master/repo/rpm-python.tar.bz2
 
 [testenv:travis-py3]
+setenv=LANG=C.UTF-8
 passenv=TRAVIS
 basepython=python3.4
 commands={[test-base]commands}
@@ -26,12 +28,14 @@ deps=
     https://raw.githubusercontent.com/nforro/rpm-bundle/master/repo/rpm-python.tar.bz2
 
 [testenv:py]
+setenv=LANG=C.UTF-8
 commands={[test-base]commands}
 sitepackages={[test-base]sitepackages}
 deps=
     {[test-base]deps}
 
 [testenv:py3]
+setenv=LANG=C.UTF-8
 basepython=python3
 sitepackages={[test-base]sitepackages}
 commands={[test-base]commands}


### PR DESCRIPTION
* Configure Gitlab CI to run tests on F25 instead of F23
* Use fixed version of astroid to make pylint work again (see: https://github.com/PyCQA/astroid/pull/422)
* Set LANG environment variable to make tests UTF-8 aware