### PR TITLE
Use entry point based approach for checkers

### DIFF
--- a/rebasehelper/checkers/__init__.py
+++ b/rebasehelper/checkers/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>

--- a/rebasehelper/checkers/abipkgdiff_tool.py
+++ b/rebasehelper/checkers/abipkgdiff_tool.py
@@ -34,6 +34,7 @@ from rebasehelper.checker import BaseChecker
 
 class AbiCheckerTool(BaseChecker):
     """ Pkgdiff compare tool. """
+
     CMD = "abipkgdiff"
     DEFAULT = True
     results_dir = ''
@@ -53,6 +54,10 @@ class AbiCheckerTool(BaseChecker):
     @classmethod
     def get_checker_name(cls):
         return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
 
     @classmethod
     def _get_packages_for_abipkgdiff(cls, input_structure=None):

--- a/rebasehelper/checkers/csmock_tool.py
+++ b/rebasehelper/checkers/csmock_tool.py
@@ -33,6 +33,7 @@ from rebasehelper.checker import BaseChecker
 
 class CsmockTool(BaseChecker):
     """ Csmock compare tool."""
+
     CMD = "csmock"
 
     @classmethod
@@ -45,6 +46,10 @@ class CsmockTool(BaseChecker):
     @classmethod
     def get_checker_name(cls):
         return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
 
     @classmethod
     def run_check(cls, results_dir):

--- a/rebasehelper/checkers/pkgdiff_tool.py
+++ b/rebasehelper/checkers/pkgdiff_tool.py
@@ -35,6 +35,7 @@ from xml.etree import ElementTree
 
 class PkgDiffTool(BaseChecker):
     """ Pkgdiff compare tool. """
+
     CMD = "pkgdiff"
     DEFAULT = True
     pkgdiff_results_filename = 'pkgdiff_reports.html'
@@ -52,6 +53,10 @@ class PkgDiffTool(BaseChecker):
     @classmethod
     def get_checker_name(cls):
         return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
 
     @classmethod
     def _get_rpm_info(cls, name, packages):

--- a/rebasehelper/checkers/rpmdiff_tool.py
+++ b/rebasehelper/checkers/rpmdiff_tool.py
@@ -36,6 +36,7 @@ from rebasehelper.checker import BaseChecker
 
 class RpmDiffTool(BaseChecker):
     """ RpmDiff compare tool."""
+
     CMD = "rpmdiff"
     DEFAULT = True
 
@@ -49,6 +50,10 @@ class RpmDiffTool(BaseChecker):
     @classmethod
     def get_checker_name(cls):
         return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
 
     @classmethod
     def _get_rpms(cls, rpm_list):

--- a/rebasehelper/tests/base_test.py
+++ b/rebasehelper/tests/base_test.py
@@ -24,6 +24,14 @@ import os
 import shutil
 import tempfile
 import pytest
+import pkg_resources
+import rebasehelper
+
+
+# make entry points accessible in case rebasehelper package is not installed
+parent_dir = os.path.dirname(os.path.dirname(rebasehelper.__file__))
+pkg_resources.working_set.add_entry(parent_dir)
+
 
 skip_on_travis = pytest.mark.skipif(os.getenv('TRAVIS') == 'true',
                                     reason='redundant on Travis CI')

--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,26 @@ setup(
     name='rebasehelper',
     version=VERSION,
     description='RebaseHelper helps you to rebase your packages.',
-    keywords='packages,easy,quick',
+    keywords='packages, easy, quick',
     author='Petr Hracek',
     author_email='phracek@redhat.com',
     url='https://github.com/rebase-helper/rebase-helper',
     license='GPLv2+',
-    packages=['rebasehelper', 'rebasehelper.checkers'],
+    packages=[
+        'rebasehelper',
+        'rebasehelper.checkers',
+        'rebasehelper.tests',
+    ],
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'rebase-helper=rebasehelper.cli:CliHelper.run'
+            'rebase-helper = rebasehelper.cli:CliHelper.run',
+        ],
+        'rebasehelper.checkers': [
+            'rpmdiff = rebasehelper.checkers.rpmdiff_tool:RpmDiffTool',
+            'pkgdiff = rebasehelper.checkers.pkgdiff_tool:PkgDiffTool',
+            'abipkgdiff = rebasehelper.checkers.abipkgdiff_tool:AbiCheckerTool',
+            'csmock = rebasehelper.checkers.csmock_tool:CsmockTool',
         ]
     },
     setup_requires=[],


### PR DESCRIPTION
Checker tools are now defined as entry points in setup.py.
This approach allows anyone to write their own checkers independently on rebase-helper codebase, in their own python package. Here is how setup.py for such package could look like:
```
from setuptools import setup

setup(
    name='CustomChecker',
    version='0.1',
    description='Custom checker tool for rebase-helper',
    author='John Doe',
    install_requires=['rebase-helper>=0.10.0'],
    packages=['custom_checker'],
    include_package_data=True,
    entry_points={
        'rebasehelper.checkers': ['custom_checker = custom_checker:CustomChecker']
    }
)
```