### PR TITLE
Implement spec hooks

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -27,7 +27,7 @@ import logging
 import six
 
 from rebasehelper.archive import Archive
-from rebasehelper.specfile import SpecFile, get_rebase_name
+from rebasehelper.specfile import SpecFile, get_rebase_name, spec_hooks_runner
 from rebasehelper.logger import logger, logger_report, LoggerHelper
 from rebasehelper import settings
 from rebasehelper import output_tool
@@ -185,6 +185,9 @@ class Application(object):
             self.rebase_spec_file.set_version(version)
             self.rebase_spec_file.set_extra_version_separator(separator)
             self.rebase_spec_file.set_extra_version(extra_version)
+
+        # run spec hooks
+        spec_hooks_runner.run_spec_hooks(self.spec_file, self.rebase_spec_file)
 
     def _initialize_data(self):
         """Function fill dictionary with default data"""

--- a/rebasehelper/spec_hooks/__init__.py
+++ b/rebasehelper/spec_hooks/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>

--- a/rebasehelper/spec_hooks/typo_fix.py
+++ b/rebasehelper/spec_hooks/typo_fix.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import re
+
+from rebasehelper.specfile import BaseSpecHook
+
+
+class TypoFixHook(BaseSpecHook):
+    """Sample spec hook that fixes typos in spec file"""
+
+    NAME = 'Typo fix'
+    REPLACEMENTS = [
+        ('chnagelog', 'changelog'),
+        ('indentional', 'intentional'),
+    ]
+
+    @classmethod
+    def get_name(cls):
+        return cls.NAME
+
+    @classmethod
+    def run(cls, spec_file, rebase_spec_file):
+        for index, line in enumerate(rebase_spec_file.spec_content):
+            for replacement in cls.REPLACEMENTS:
+                line = re.sub(replacement[0], replacement[1], line)
+            rebase_spec_file.spec_content[index] = line
+        rebase_spec_file.save()

--- a/rebasehelper/tests/testing_files/test.spec
+++ b/rebasehelper/tests/testing_files/test.spec
@@ -1,7 +1,7 @@
 Summary: A testing spec file
 Name: test
 Version: 1.0.2
-Release: 33%{?dist}
+Release: 34%{?dist}
 License: GPL2+
 Group: System Environment
 URL: http://testing.org
@@ -63,6 +63,9 @@ make check
 %{_libdir}/my_test.so
 
 %changelog
+* Wed Apr 26 2017 Nikola Forró <nforro@redhat.com> - 1.0.2-34
+- This is chnagelog entry with some indentional typos
+
 * Wed Nov 12 2014 Tomas Hozza <thozza@redhat.com> 1.0.0-33
 - Bump the release for testing purposes
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     packages=[
         'rebasehelper',
         'rebasehelper.checkers',
+        'rebasehelper.spec_hooks',
         'rebasehelper.tests',
     ],
     include_package_data=True,
@@ -53,6 +54,9 @@ setup(
             'pkgdiff = rebasehelper.checkers.pkgdiff_tool:PkgDiffTool',
             'abipkgdiff = rebasehelper.checkers.abipkgdiff_tool:AbiCheckerTool',
             'csmock = rebasehelper.checkers.csmock_tool:CsmockTool',
+        ],
+        'rebasehelper.spec_hooks': [
+            'typo_fix = rebasehelper.spec_hooks.typo_fix:TypoFixHook',
         ]
     },
     setup_requires=[],


### PR DESCRIPTION
Spec hooks are implemented using entry points based approach.
Sample **typo fix** hook and test for it is included.
This PR obsoletes #237.