### PR TITLE
Use entry points based approach also for build tools

### DIFF
--- a/rebasehelper/build_tools/__init__.py
+++ b/rebasehelper/build_tools/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>

--- a/rebasehelper/build_tools/copr_tool.py
+++ b/rebasehelper/build_tools/copr_tool.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os
+
+from rebasehelper.utils import CoprHelper
+from rebasehelper.logger import logger
+from rebasehelper.build_helper import BuildToolBase
+from rebasehelper.build_helper import BinaryPackageBuildError
+
+
+class CoprBuildTool(BuildToolBase):
+    """
+    Class representing Copr build tool.
+    """
+
+    CMD = "copr"
+    LOCAL = False
+    logs = []
+    copr_helper = None
+
+    prefix = 'rebase-helper-'
+    chroot = 'fedora-rawhide-x86_64'
+    description = 'Repository containing rebase-helper builds.'
+    instructions = '''You can use this repository to test functionality
+                      of rebased packages.'''
+
+    @classmethod
+    def match(cls, cmd=None):
+        if cmd == cls.CMD:
+            return True
+        else:
+            return False
+
+    @classmethod
+    def get_build_tool_name(cls):
+        return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
+
+    @classmethod
+    def accepts_options(cls):
+        return False
+
+    @classmethod
+    def creates_tasks(cls):
+        return True
+
+    @classmethod
+    def _build_rpms(cls, srpm, name, **kwargs):
+        project = cls.prefix + name
+        client = cls.copr_helper.get_client()
+        cls.copr_helper.create_project(client, project, cls.chroot,
+                                       cls.description, cls.instructions)
+        build_id = cls.copr_helper.build(client, project, srpm)
+        if kwargs['builds_nowait']:
+            return None, None, build_id
+        build_url = cls.copr_helper.get_build_url(client, build_id)
+        logger.info('Copr build is here:\n' + build_url)
+        failed = not cls.copr_helper.watch_build(client, build_id)
+        destination = os.path.dirname(srpm).replace('SRPM', 'RPM')
+        rpms, logs = cls.copr_helper.download_build(client,
+                                                    build_id,
+                                                    destination)
+        if failed:
+            logger.info('Copr build failed {}'.format(build_url))
+            logs.append(build_url)
+            cls.logs.append(build_url)
+            raise BinaryPackageBuildError
+        logs.append(build_url)
+        return rpms, logs, build_id
+
+    @classmethod
+    def build(cls, spec, sources, patches, results_dir, **kwargs):
+        """
+        Builds the SRPM using rpmbuild
+        Builds the RPMs using copr
+
+        :param spec: absolute path to the SPEC file.
+        :param sources: list with absolute paths to SOURCES
+        :param patches: list with absolute paths to PATCHES
+        :param results_dir: absolute path to DIR where results should be stored
+        :return: dict with:
+                 'srpm' -> absolute path to SRPM
+                 'rpm' -> list with absolute paths to RPMs
+                 'logs' -> list with absolute paths to build_logs
+        """
+        # build SRPM
+        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir)
+        # build RPMs
+        rpm_results_dir = os.path.join(results_dir, "RPM")
+        os.makedirs(rpm_results_dir)
+        if not cls.copr_helper:
+            cls.copr_helper = CoprHelper()
+        rpms, rpm_logs, build_id = cls._build_rpms(srpm, **kwargs)
+        if rpm_logs:
+            cls.logs.extend(rpm_logs)
+        return {'srpm': srpm,
+                'rpm': rpms,
+                'logs': cls.logs,
+                'copr_build_id': build_id}
+
+    @classmethod
+    def get_logs(cls):
+        return {'logs': cls.logs}
+
+    @classmethod
+    def get_task_info(cls, data):
+        if not cls.copr_helper:
+            cls.copr_helper = CoprHelper()
+        client = cls.copr_helper.get_client()
+        build_url = cls.copr_helper.get_build_url(client, data['copr_build_id'])
+        message = "Copr build for '%s' version is: %s"
+        return message % (data['version'], build_url)
+
+    @classmethod
+    def get_detached_task(cls, task_id, results_dir):
+        if not cls.copr_helper:
+            cls.copr_helper = CoprHelper()
+        client = cls.copr_helper.get_client()
+        build_id = int(task_id)
+        status = cls.copr_helper.get_build_status(client, build_id)
+        if status in ['importing', 'pending', 'starting', 'running']:
+            logger.info('Copr build is not finished yet. Try again later')
+            return None, None
+        else:
+            rpm, logs = cls.copr_helper.download_build(client, build_id, results_dir)
+            if status not in ['succeeded', 'skipped']:
+                logger.info('Copr build {} did not complete successfully'.format(build_id))
+                return None, None
+            return rpm, logs
+

--- a/rebasehelper/build_tools/koji_tool.py
+++ b/rebasehelper/build_tools/koji_tool.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os
+import six
+import koji  # pylint: disable=import-error
+
+from rebasehelper.utils import KojiHelper
+from rebasehelper.logger import logger
+from rebasehelper.build_helper import BuildToolBase
+from rebasehelper.build_helper import BinaryPackageBuildError
+
+
+class KojiBuildTool(BuildToolBase):
+    """
+    Class representing Koji build tool.
+    """
+
+    CMD = "koji"
+    LOCAL = False
+    logs = []
+    koji_helper = None
+
+    # Taken from https://github.com/fedora-infra/the-new-hotness/blob/develop/fedmsg.d/hotness-example.py
+    koji_web = "koji.fedoraproject.org"
+    server = "https://%s/kojihub" % koji_web
+    weburl = "http://%s/koji" % koji_web
+    git_url = 'http://pkgs.fedoraproject.org/cgit/{package}.git'
+    opts = {'scratch': True}
+    target_tag = 'rawhide'
+    priority = 30
+
+    # Taken from  https://github.com/fedora-infra/the-new-hotness/blob/develop/hotness/buildsys.py#L78-L123
+
+    @classmethod
+    def match(cls, cmd=None):
+        if cmd == cls.CMD:
+            return True
+        else:
+            return False
+
+    @classmethod
+    def get_build_tool_name(cls):
+        return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
+
+    @classmethod
+    def accepts_options(cls):
+        return False
+
+    @classmethod
+    def creates_tasks(cls):
+        return True
+
+    @classmethod
+    def _scratch_build(cls, source, **kwargs):
+        session = cls.koji_helper.session_maker()
+        remote = cls.koji_helper.upload_srpm(session, source)
+        task_id = session.build(remote, cls.target_tag, cls.opts, priority=cls.priority)
+        if kwargs['builds_nowait']:
+            return None, None, task_id
+        weburl = cls.weburl + '/taskinfo?taskID=%i' % task_id
+        logger.info('Koji task_id is here:\n' + weburl)
+        session.logout()
+        task_dict = cls.koji_helper.watch_koji_tasks(session, [task_id])
+        task_list = []
+        package_failed = False
+        for key in six.iterkeys(task_dict):
+            if task_dict[key] == koji.TASK_STATES['FAILED']:
+                package_failed = True
+            task_list.append(key)
+        rpms, logs = cls.koji_helper.download_scratch_build(session,
+                                                            task_list,
+                                                            os.path.dirname(source).replace('SRPM', 'RPM'))
+        if package_failed:
+            weburl = '%s/taskinfo?taskID=%i' % (cls.weburl, task_list[0])
+            logger.info('RPM build failed %s', weburl)
+            logs.append(weburl)
+            cls.logs.append(weburl)
+            raise BinaryPackageBuildError
+        logs.append(weburl)
+        return rpms, logs, task_id
+
+    @classmethod
+    def get_logs(cls):
+        return {'logs': cls.logs}
+
+    @classmethod
+    def wait_for_task(cls, build_dict, results_dir):
+        if not cls.koji_helper:
+            cls.koji_helper = KojiHelper()
+        task_id = build_dict.get('koji_task_id')
+        if not task_id:
+            return None, None
+        rpm, logs = build_dict.get('rpm'), build_dict.get('logs')
+        while not rpm:
+            rpm, logs = cls.koji_helper.get_koji_tasks(task_id, results_dir)
+        return rpm, logs
+
+    @classmethod
+    def get_task_info(cls, build_dict):
+        message = "Scratch build for '%s' version is: http://koji.fedoraproject.org/koji/taskinfo?taskID=%s"
+        return message % (build_dict['version'], build_dict['koji_task_id'])
+
+    @classmethod
+    def get_detached_task(cls, task_id, results_dir):
+        if not cls.koji_helper:
+            cls.koji_helper = KojiHelper()
+        try:
+            return cls.koji_helper.get_koji_tasks(task_id, results_dir)
+        except TypeError:
+            logger.info('Koji tasks are not finished yet. Try again later')
+            return None, None
+
+    @classmethod
+    def build(cls, spec, sources, patches, results_dir, **kwargs):
+        """
+        Builds the SRPM using rpmbuild
+        Builds the RPMs using koji
+
+        :param spec: absolute path to the SPEC file.
+        :param sources: list with absolute paths to SOURCES
+        :param patches: list with absolute paths to PATCHES
+        :param results_dir: absolute path to DIR where results should be stored
+        :param upstream_monitoring: specify if build is handled by upstream monitoring
+        :return: dict with:
+                 'srpm' -> absolute path to SRPM
+                 'rpm' -> list with absolute paths to RPMs
+                 'logs' -> list with absolute paths to build_logs
+        """
+        # build SRPM
+        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir)
+        # build RPMs
+        rpm_results_dir = os.path.join(results_dir, "RPM")
+        os.makedirs(rpm_results_dir)
+        if not cls.koji_helper:
+            cls.koji_helper = KojiHelper()
+        rpms, rpm_logs, koji_task_id = cls._scratch_build(srpm, **kwargs)
+        if rpm_logs:
+            cls.logs.extend(rpm_logs)
+        return {'srpm': srpm,
+                'rpm': rpms,
+                'logs': cls.logs,
+                'koji_task_id': koji_task_id}
+

--- a/rebasehelper/build_tools/mock_tool.py
+++ b/rebasehelper/build_tools/mock_tool.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os
+
+from rebasehelper.utils import ProcessHelper
+from rebasehelper.logger import logger
+from rebasehelper.utils import PathHelper
+from rebasehelper.build_helper import BuildTemporaryEnvironment
+from rebasehelper.build_helper import BuildToolBase
+from rebasehelper.build_helper import BinaryPackageBuildError
+
+
+class MockTemporaryEnvironment(BuildTemporaryEnvironment):
+    """
+    Class representing temporary environment for MockBuildTool.
+    """
+
+    def _create_directory_structure(self):
+        # create directory structure
+        for dir_name in ['SOURCES', 'SPECS', 'RESULTS']:
+            self._env[self.TEMPDIR + '_' + dir_name] = os.path.join(
+                self._env[self.TEMPDIR], dir_name)
+            logger.debug("Creating '%s'",
+                         self._env[self.TEMPDIR + '_' + dir_name])
+            os.makedirs(self._env[self.TEMPDIR + '_' + dir_name])
+
+
+class MockBuildTool(BuildToolBase):
+    """
+    Class representing Mock build tool.
+    """
+
+    CMD = "mock"
+    DEFAULT = True
+    logs = []
+
+    @classmethod
+    def _build_rpm(cls, srpm, results_dir, root=None, arch=None, builder_options=None):
+        """Build RPM using mock."""
+        logger.info("Building RPMs")
+        output = os.path.join(results_dir, "mock_output.log")
+
+        cmd = [cls.CMD, '--rebuild', srpm, '--resultdir', results_dir]
+        if root is not None:
+            cmd.extend(['--root', root])
+        if arch is not None:
+            cmd.extend(['--arch', arch])
+        if builder_options is not None:
+            cmd.extend(builder_options)
+
+        ret = ProcessHelper.run_subprocess(cmd, output=output)
+
+        if ret != 0:
+            return None
+        else:
+            return [f for f in PathHelper.find_all_files(results_dir, '*.rpm') if not f.endswith('.src.rpm')]
+
+    @classmethod
+    def match(cls, cmd=None):
+        if cmd == cls.CMD:
+            return True
+        else:
+            return False
+
+    @classmethod
+    def get_build_tool_name(cls):
+        return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
+
+    @classmethod
+    def accepts_options(cls):
+        return True
+
+    @classmethod
+    def creates_tasks(cls):
+        return False
+
+    @classmethod
+    def build(cls, spec, sources, patches, results_dir, root=None, arch=None, **kwargs):
+        """
+        Builds the SRPM and RPM using mock
+
+        :param spec: absolute path to a SPEC file
+        :param sources: list with absolute paths to SOURCES
+        :param patches: list with absolute paths to PATCHES
+        :param results_dir: absolute path to directory where results will be stored
+        :param root: mock root used for building
+        :param arch: architecture to build the RPM for
+        :return: dict with:
+                 'srpm' -> absolute path to SRPM
+                 'rpm' -> list with absolute paths to RPMs
+                 'logs' -> list with absolute paths to logs
+        """
+        # build SRPM
+        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir)
+
+        # build RPMs
+        rpm_results_dir = os.path.join(results_dir, "RPM")
+        with MockTemporaryEnvironment(sources, patches, spec, rpm_results_dir) as tmp_env:
+            env = tmp_env.env()
+            tmp_results_dir = env.get(MockTemporaryEnvironment.TEMPDIR_RESULTS)
+            rpms = cls._build_rpm(srpm, tmp_results_dir, builder_options=cls.get_builder_options(**kwargs))
+            # remove SRPM - side product of building RPM
+            tmp_srpm = PathHelper.find_first_file(tmp_results_dir, "*.src.rpm")
+            if tmp_srpm is not None:
+                os.unlink(tmp_srpm)
+
+        if rpms is None:
+            # We need to be inform what directory to analyze and what spec file failed
+            cls.logs.extend([l for l in PathHelper.find_all_files(rpm_results_dir, '*.log')])
+            raise BinaryPackageBuildError("Building RPMs failed!", rpm_results_dir, spec)
+        else:
+            logger.info("Building RPMs finished successfully")
+
+        rpms = [os.path.join(rpm_results_dir, os.path.basename(f)) for f in rpms]
+        logger.debug("Successfully built RPMs: '%s'", str(rpms))
+
+        # gather logs
+        cls.logs.extend([l for l in PathHelper.find_all_files(rpm_results_dir, '*.log')])
+        logger.debug("logs: '%s'", str(cls.logs))
+
+        return {'srpm': srpm,
+                'rpm': rpms,
+                'logs': cls.logs}
+
+    @classmethod
+    def get_logs(cls):
+        return {'logs': cls.logs}

--- a/rebasehelper/build_tools/rpmbuild_tool.py
+++ b/rebasehelper/build_tools/rpmbuild_tool.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os
+
+from rebasehelper.utils import ProcessHelper
+from rebasehelper.logger import logger
+from rebasehelper.utils import PathHelper
+from rebasehelper.utils import RpmHelper
+from rebasehelper.utils import ConsoleHelper
+from rebasehelper.build_helper import RpmbuildTemporaryEnvironment
+from rebasehelper.build_helper import BuildToolBase
+from rebasehelper.build_helper import BinaryPackageBuildError
+from rebasehelper.exceptions import RebaseHelperError
+
+
+class RpmbuildBuildTool(BuildToolBase):
+    """
+    Class representing rpmbuild build tool.
+    """
+
+    CMD = "rpmbuild"
+    logs = []
+
+    @classmethod
+    def _build_rpm(cls, srpm, workdir, results_dir, builder_options=None):
+        """
+        Build RPM using rpmbuild.
+
+        :param srpm: abs path to SRPM
+        :param workdir: abs path to working directory with rpmbuild directory
+                        structure, which will be used as HOME dir.
+        :param results_dir: abs path to dir where the log should be placed.
+        :return: If build process ends successfully returns list of abs paths
+                 to built RPMs, otherwise 'None'.
+        """
+        logger.info("Building RPMs")
+        output = os.path.join(results_dir, "build.log")
+
+        cmd = [cls.CMD, '--rebuild', srpm]
+        if builder_options is not None:
+            cmd.extend(builder_options)
+        ret = ProcessHelper.run_subprocess_cwd_env(cmd,
+                                                   env={'HOME': workdir},
+                                                   output=output)
+
+        if ret != 0:
+            return None
+        else:
+            return [f for f in PathHelper.find_all_files(workdir, '*.rpm') if not f.endswith('.src.rpm')]
+
+    @classmethod
+    def match(cls, cmd=None):
+        if cmd == cls.CMD:
+            return True
+        else:
+            return False
+
+    @classmethod
+    def get_build_tool_name(cls):
+        return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
+
+    @classmethod
+    def accepts_options(cls):
+        return True
+
+    @classmethod
+    def creates_tasks(cls):
+        return False
+
+    @classmethod
+    def prepare(cls, spec):
+        """
+        Checks if all build dependencies are installed. If not, asks user whether they should be installed.
+        If he agrees, installs build dependencies using PolicyKit.
+
+        :param spec: SpecFile object
+        """
+        req_pkgs = spec.get_requires()
+        if not RpmHelper.all_packages_installed(req_pkgs):
+            if ConsoleHelper.get_message('\nSome build dependencies are missing. Do you want to install them now'):
+                if RpmHelper.install_build_dependencies(spec.get_path()) != 0:
+                    raise RebaseHelperError('Failed to install build dependencies')
+
+    @classmethod
+    def build(cls, spec, sources, patches, results_dir, **kwargs):
+        """
+        Builds the SRPM and RPMs using rpmbuild
+
+        :param spec: absolute path to the SPEC file.
+        :param sources: list with absolute paths to SOURCES
+        :param patches: list with absolute paths to PATCHES
+        :param results_dir: absolute path to DIR where results should be stored
+        :return: dict with:
+                 'srpm' -> absolute path to SRPM
+                 'rpm' -> list with absolute paths to RPMs
+                 'logs' -> list with absolute paths to build_logs
+        """
+        # build SRPM
+        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir)
+
+        # build RPMs
+        rpm_results_dir = os.path.join(results_dir, "RPM")
+        with RpmbuildTemporaryEnvironment(sources, patches, spec, rpm_results_dir) as tmp_env:
+            env = tmp_env.env()
+            tmp_dir = tmp_env.path()
+            tmp_results_dir = env.get(RpmbuildTemporaryEnvironment.TEMPDIR_RESULTS)
+            rpms = cls._build_rpm(srpm, tmp_dir, tmp_results_dir, builder_options=cls.get_builder_options(**kwargs))
+
+        if rpms is None:
+            cls.logs.extend([l for l in PathHelper.find_all_files(rpm_results_dir, '*.log')])
+            raise BinaryPackageBuildError("Building RPMs failed!")
+        else:
+            logger.info("Building RPMs finished successfully")
+
+        # RPMs paths in results_dir
+        rpms = [os.path.join(rpm_results_dir, os.path.basename(f)) for f in rpms]
+        logger.debug("Successfully built RPMs: '%s'", str(rpms))
+
+        # gather logs
+        cls.logs.extend([l for l in PathHelper.find_all_files(rpm_results_dir, '*.log')])
+        logger.debug("logs: '%s'", str(cls.logs))
+
+        return {'srpm': srpm,
+                'rpm': rpms,
+                'logs': cls.logs}
+
+    @classmethod
+    def get_logs(cls):
+        return {'logs': cls.logs}
+

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -166,7 +166,7 @@ class CLI(object):
             "--builds-nowait",
             default=False,
             action="store_true",
-            help="do not wait for koji or copr builds to finish"
+            help="do not wait for remote builds to finish"
         )
         # deprecated argument, kept for backward compatibility
         parser.add_argument(
@@ -180,7 +180,7 @@ class CLI(object):
             dest="build_tasks",
             metavar="OLD_TASK,NEW_TASK",
             type=lambda s: s.split(','),
-            help="comma-separated koji or copr task ids"
+            help="comma-separated remote build task ids"
         )
         parser.add_argument(
             "--results-dir",

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     license='GPLv2+',
     packages=[
         'rebasehelper',
+        'rebasehelper.build_tools',
         'rebasehelper.checkers',
         'rebasehelper.spec_hooks',
         'rebasehelper.tests',
@@ -48,6 +49,12 @@ setup(
     entry_points={
         'console_scripts': [
             'rebase-helper = rebasehelper.cli:CliHelper.run',
+        ],
+        'rebasehelper.build_tools': [
+            'rpmbuild = rebasehelper.build_tools.rpmbuild_tool:RpmbuildBuildTool',
+            'mock = rebasehelper.build_tools.mock_tool:MockBuildTool',
+            'koji = rebasehelper.build_tools.koji_tool:KojiBuildTool',
+            'copr = rebasehelper.build_tools.copr_tool:CoprBuildTool',
         ],
         'rebasehelper.checkers': [
             'rpmdiff = rebasehelper.checkers.rpmdiff_tool:RpmDiffTool',


### PR DESCRIPTION
Summary of changes:
* build tools were separated and moved from `build_helper.py` into `build_tools` package
* code from `Application.check_build_requires` was moved to `RpmbuildBuildTool.prepare` method
* build task logic from `Application` was moved to task related methods of **koji** and **copr** build tools
* **koji** build tool is now available only if `koji` module can be successfully imported
