### PR TITLE
Fix documentation making

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo " help                    show this text"
 	@echo " clean                   remove python bytecode and temp files"
 	@echo " install                 install program on current system"
+	@echo " build                   build program"
 	@echo " log                     prepare changelog for spec file"
 	@echo " source                  create source tarball"
 	@echo " test                    run tests/run_tests.py"
@@ -25,6 +26,10 @@ install:
 	@python setup.py install
 
 
+build:
+	@python setup.py build
+
+
 log:
 	@(LC_ALL=C date +"* %a %b %e %Y `git config --get user.name` <`git config --get user.email`> - VERSION"; git log --pretty="format:- %s (%an)" | cat) | less
 
@@ -32,11 +37,12 @@ log:
 source: clean
 	@python setup.py sdist
 
-html: 
+
+html: build
 	make -f Makefile.docs html
 
 
-man:
+man: build
 	make -f Makefile.docs man
 
 

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -128,7 +128,7 @@ text:
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
 man:
-	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	$(SPHINXBUILD) -b custom-man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rebase-helper
 
-[![Code Health](https://landscape.io/github/phracek/rebase-helper/master/landscape.svg?style=flat)](https://landscape.io/github/phracek/rebase-helper/master) [![GitLab CI build status](https://gitlab.com/rebase-helper/rebase-helper/badges/master/build.svg)](https://gitlab.com/rebase-helper/rebase-helper/commits/master) [![Travis CI build status](https://travis-ci.org/rebase-helper/rebase-helper.svg?branch=master)](https://travis-ci.org/rebase-helper/rebase-helper)
+[![Code Health](https://landscape.io/github/phracek/rebase-helper/master/landscape.svg?style=flat)](https://landscape.io/github/phracek/rebase-helper/master) [![GitLab CI build status](https://gitlab.com/rebase-helper/rebase-helper/badges/master/build.svg)](https://gitlab.com/rebase-helper/rebase-helper/commits/master) [![Travis CI build status](https://travis-ci.org/rebase-helper/rebase-helper.svg?branch=master)](https://travis-ci.org/rebase-helper/rebase-helper) [![Documentation build status](https://readthedocs.org/projects/rebase-helper/badge/?version=latest)](https://readthedocs.org/projects/rebase-helper)
 
 This tool helps you to rebase your package to the latest version.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -282,4 +282,4 @@ texinfo_documents = [
 # This value contains a list of modules to be mocked up. This is useful
 # when some external dependencies are not met at build time and break
 # the building process.
-autodoc_mock_imports = ['backports.lzma', 'rpm', 'koji']
+autodoc_mock_imports = ['rpm', 'koji']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 
 import sys
 import os
+import pkg_resources
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -21,6 +22,11 @@ import os
 sys.path.insert(0, os.path.abspath('.'))
 rebase_helper_dir = os.path.abspath('..')
 sys.path.insert(0, rebase_helper_dir)
+
+# Make entry points accessible in case rebasehelper package is not installed,
+import rebasehelper
+parent_dir = os.path.dirname(os.path.dirname(rebasehelper.__file__))
+pkg_resources.working_set.add_entry(parent_dir)
 
 from rebasehelper import version as rh_version
 


### PR DESCRIPTION
* Entry points need to be accessible also when building documentation for all options to be properly generated.
* Project must be built before generating documentation, otherwise egg-info directory with entry points could be missing or invalid.
* Building man page using `make man` command from project directory now uses **custom-man** builder.
* `backports.lzma` module is no longer being mocked up on readthedocs, as documenation builds were failing because of that.