### PR TITLE
Implement pypi_url_fix url hook

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -64,7 +64,7 @@ class Application(object):
         Initialize the application
 
         :param cli_conf: CLI object with configuration gathered from commandline
-        :return: 
+        :return:
         """
         results_store.clear()
 
@@ -187,6 +187,10 @@ class Application(object):
 
         # run spec hooks
         spec_hooks_runner.run_spec_hooks(self.spec_file, self.rebase_spec_file)
+
+        # spec file object has been sanitized downloading can proceed
+        if self.spec_file.download:
+            self.rebase_spec_file.download_remote_sources()
 
     def _initialize_data(self):
         """Function fill dictionary with default data"""

--- a/rebasehelper/spec_hooks/pypi_url_fix.py
+++ b/rebasehelper/spec_hooks/pypi_url_fix.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import re
+
+from rebasehelper.specfile import BaseSpecHook
+
+
+class PyPIURLFixHook(BaseSpecHook):
+    """
+    SpecHook for transforming old nonfunctional python package url to
+    a safe url(eg. https://pypi.* to https://files.pythonhosted.*)
+    """
+
+    NAME = 'PyPI URL Fix'
+    SOURCES_URL_TRANSFORMATIONS = [
+        ('https?://pypi.python.org/', 'https://files.pythonhosted.org/'),
+    ]
+
+    @classmethod
+    def get_name(cls):
+        return cls.NAME
+
+    @classmethod
+    def run(cls, spec_file, rebase_spec_file):
+        """
+        Run _transform_url() for all sources to replace all pypi.* urls by
+        files.pythonhosted.* urls.
+        """
+        for index, line in enumerate(rebase_spec_file.spec_content):
+            if line.startswith("Source"):
+                rebase_spec_file.spec_content[index] = cls._transform_url(line)
+        rebase_spec_file.save()
+
+    @classmethod
+    def _transform_url(cls, line):
+        """
+        Perform predefined URL transformations
+        """
+        for trans in cls.SOURCES_URL_TRANSFORMATIONS:
+            if re.search(r".*https?://pypi.python.org/.*", line):
+                line = re.sub(trans[0], trans[1], line)
+        return line

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -182,10 +182,6 @@ class SpecFile(object):
         self.patches = self._get_initial_patches_list()
         self.macros = MacroHelper.dump()
 
-        # TODO: don't call this at all in SPEC file methods
-        if self.download:
-            self.download_remote_sources()
-
     ###########################
     # SOURCES RELATED METHODS #
     ###########################

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -29,6 +29,7 @@ from .base_test import BaseTest
 from rebasehelper.specfile import SpecFile, spec_hooks_runner
 from rebasehelper.build_log_analyzer import BuildLogAnalyzer
 from rebasehelper.spec_hooks.typo_fix import TypoFixHook
+from rebasehelper.spec_hooks.pypi_url_fix import PyPIURLFixHook
 
 
 class TestSpecFile(BaseTest):
@@ -43,6 +44,7 @@ class TestSpecFile(BaseTest):
     SOURCE_4 = 'file.txt.bz2'
     SOURCE_5 = 'documentation.tar.xz'
     SOURCE_6 = 'misc.zip'
+    SOURCE_7 = 'positional-1.1.0.tar.gz'
     PATCH_1 = 'test-testing.patch'
     PATCH_2 = 'test-testing2.patch'
     PATCH_3 = 'test-testing3.patch'
@@ -117,9 +119,10 @@ class TestSpecFile(BaseTest):
         assert self.SPEC_FILE_OBJECT.get_archive() == self.OLD_ARCHIVE
 
     def test_get_sources(self):
-        sources = [self.SOURCE_0, self.SOURCE_1, self.SOURCE_4, self.SOURCE_5, self.SOURCE_6, self.OLD_ARCHIVE]
+        sources = [self.SOURCE_0, self.SOURCE_1, self.SOURCE_4, self.SOURCE_5,
+                   self.SOURCE_6, self.SOURCE_7, self.OLD_ARCHIVE]
         sources = [os.path.join(self.WORKING_DIR, f) for f in sources]
-        assert len(set(sources).intersection(set(self.SPEC_FILE_OBJECT.get_sources()))) == 6
+        assert len(set(sources).intersection(set(self.SPEC_FILE_OBJECT.get_sources()))) == 7
         # The Source0 has to be always in the beginning
         assert self.SPEC_FILE_OBJECT.get_archive() == 'test-1.0.2.tar.xz'
 
@@ -230,6 +233,7 @@ class TestSpecFile(BaseTest):
                             'Source4: file.txt.bz2\n',
                             'Source5: documentation.tar.xz\n',
                             'Source6: misc.zip\n',
+                            'Source7: https://pypi.python.org/packages/source/p/positional/positional-1.1.0.tar.gz\n',
                             'Patch1: test-testing.patch\n',
                             'Patch2: test-testing2.patch\n',
                             'Patch3: test-testing3.patch\n',
@@ -448,3 +452,9 @@ class TestSpecFile(BaseTest):
         assert '- This is chnagelog entry with some indentional typos\n' in self.SPEC_FILE_OBJECT.spec_content
         spec_hooks_runner.run_spec_hooks(None, self.SPEC_FILE_OBJECT)
         assert '- This is changelog entry with some intentional typos\n' in self.SPEC_FILE_OBJECT.spec_content
+
+    def test_pypi_to_python_hosted_url_trans(self):
+        assert PyPIURLFixHook.get_name() in spec_hooks_runner.spec_hooks
+        assert 'https://pypi.python.org/' in self.SPEC_FILE_OBJECT._get_raw_source_string(7)
+        spec_hooks_runner.run_spec_hooks(None, self.SPEC_FILE_OBJECT)
+        assert 'https://files.pythonhosted.org/' in self.SPEC_FILE_OBJECT._get_raw_source_string(7)

--- a/rebasehelper/tests/testing_files/test.spec
+++ b/rebasehelper/tests/testing_files/test.spec
@@ -15,6 +15,7 @@ Source2: ftp://test.com/test-source.sh
 Source4: file.txt.bz2
 Source5: documentation.tar.xz
 Source6: misc.zip
+Source7: https://pypi.python.org/packages/source/p/positional/positional-1.1.0.tar.gz
 Patch1: test-testing.patch
 Patch2: test-testing2.patch
 Patch3: test-testing3.patch

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         ],
         'rebasehelper.spec_hooks': [
             'typo_fix = rebasehelper.spec_hooks.typo_fix:TypoFixHook',
+            'pypi_url_fix = rebasehelper.spec_hooks.pypi_url_fix:PyPIURLFixHook',
         ]
     },
     setup_requires=[],


### PR DESCRIPTION
Transforms https://pypi.* url to https://files.pythonhosted.*

Move downloading of the sources just after the run_spec_hooks,
to allow using the modified sources url.

Obsoletes #223
References #186