### PR TITLE
Update m2r in doc requirements

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -6,4 +6,4 @@ pyquery
 six
 sphinx_rtd_theme
 # use fixed version of m2r, see: https://github.com/miyakogi/m2r/pull/3
-git+https://github.com/nforro/m2r.git@d649fc4dd4e20234404884a59a556e5a3793505b#egg=m2r
+git+https://github.com/miyakogi/m2r.git@d649fc4dd4e20234404884a59a556e5a3793505b#egg=m2r


### PR DESCRIPTION
Pull request https://github.com/miyakogi/m2r/pull/3 has been merged, so the original URL is no longer valid.