### PR TITLE
Add missing dnf-plugins-core dependency

### DIFF
--- a/test-deps-fedora.txt
+++ b/test-deps-fedora.txt
@@ -22,3 +22,4 @@ rpmlint
 libabigail
 pkgdiff
 dnf
+dnf-plugins-core


### PR DESCRIPTION
It is needed for `dnf-builddep` plugin (and not installed by default in Fedora rawhide Docker image).