### PR TITLE
mock related fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   # don't start any services (mainly not the default ones)
   services:
   script:
+    - dnf -y install yum
     - dnf -y install $(cat test-deps-fedora.txt)
     - PYTEST_ADDOPTS="-m 'not optional'" tox
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -21,4 +21,4 @@ $(TEST_IMAGE):
 	git archive HEAD | $(DOCKER) run \
 		--cap-add=SYS_ADMIN --rm -i -v /build -w /build -e PY_COLORS=1 \
 		-e TOXENV="$(TOXENV)" -e PYTEST_ADDOPTS="$(PYTEST_ADDOPTS)" $(IMAGE) \
-		/bin/sh -c 'dnf -y install tar && tar -x && dnf -y install $$(cat test-deps-fedora.txt) && tox'
+		/bin/sh -c 'dnf -y install tar && tar -x && dnf -y install yum && dnf -y install $$(cat test-deps-fedora.txt) && tox'

--- a/rebasehelper/tests/functional/conftest.py
+++ b/rebasehelper/tests/functional/conftest.py
@@ -39,9 +39,11 @@ def make_logs_report():
         'old/SRPM/build.log',
         'old/RPM/build.log',
         'old/RPM/root.log',
+        'old/RPM/mock_output.log',
         'new/SRPM/build.log',
         'new/RPM/build.log',
         'new/RPM/root.log',
+        'new/RPM/mock_output.log',
     ]
     report = []
     for log in logs:


### PR DESCRIPTION
`mock-1.4.2-1` no longer depends on yum, but it fails to create `/etc/mock/default.cfg` symlink without it, see: https://bugzilla.redhat.com/show_bug.cgi?id=1461839