### PR TITLE
Add possibility to download old build from Koji

### DIFF
--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -33,6 +33,7 @@ from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.build_helper import Builder
 from rebasehelper.checker import checkers_runner
 from rebasehelper.output_tool import OutputTool
+from rebasehelper.utils import KojiHelper
 
 
 class CustomHelpFormatter(argparse.HelpFormatter):
@@ -206,6 +207,13 @@ class CLI(object):
             help="enable arbitrary local builder option(s), enclose %(metavar)s in quotes "
                  "and note that = before it is mandatory"
         )
+        if KojiHelper.functional:
+            parser.add_argument(
+                "--get-old-build-from-koji",
+                default=False,
+                action="store_true",
+                help="do not build old sources, download latest build from Koji instead"
+            )
         return parser
 
     def __init__(self, args=None):

--- a/rebasehelper/tests/test_cli.py
+++ b/rebasehelper/tests/test_cli.py
@@ -26,34 +26,39 @@ from rebasehelper.cli import CLI
 class TestCLI(object):
     def test_cli_unit(self):
         """Function tests cli class with all arguments"""
-        conf = {'build_only': True,
-                'patch_only': True,
-                'sources': 'test-1.0.3.tar.gz',
-                'verbose': True,
-                'buildtool': 'rpmbuild',
-                'difftool': 'vimdiff',
-                'pkgcomparetool': ['rpmdiff'],
-                'outputtool': 'json',
-                'keep_workspace': True,
-                'not_download_sources': True,
-                'cont': True,
-                'non_interactive': True,
-                'disable_inapplicable_patches': False,
-                'comparepkgs': 'test_dir',
-                'fedpkg_build_tasks': None,
-                'build_tasks': ['123456', '654321'],
-                'builds_nowait': True,
-                'build_retries': 2,
-                'results_dir': '/tmp/rebase-helper',
-                'builder_options': '\"-v\"'}
-        arguments = ['--build-only', '--patch-only', 'test-1.0.3.tar.gz', '--verbose',
-                     '--buildtool', 'rpmbuild', '--pkgcomparetool',
-                     'rpmdiff', '--outputtool', 'json', '--keep-workspace', '--not-download-sources', '--continue',
-                     '--non-interactive', '--comparepkgs-only', 'test_dir',
-                     '--builds-nowait', '--build-tasks', '123456,654321',
-                     '--build-retries', '2',
-                     '--results-dir', '/tmp/rebase-helper',
-                     '--builder-options=\"-v\"']
+        conf = {
+            'build_only': True,
+            'patch_only': True,
+            'sources': 'test-1.0.3.tar.gz',
+            'verbose': True,
+            'buildtool': 'rpmbuild',
+            'difftool': 'vimdiff',
+            'pkgcomparetool': ['rpmdiff'],
+            'outputtool': 'json',
+            'keep_workspace': True,
+            'not_download_sources': True,
+            'cont': True,
+            'non_interactive': True,
+            'disable_inapplicable_patches': False,
+            'comparepkgs': 'test_dir',
+            'fedpkg_build_tasks': None,
+            'build_tasks': ['123456', '654321'],
+            'builds_nowait': True,
+            'build_retries': 2,
+            'results_dir': '/tmp/rebase-helper',
+            'builder_options': '\"-v\"',
+            'get_old_build_from_koji': False,
+        }
+        arguments = [
+            '--build-only', '--patch-only', 'test-1.0.3.tar.gz', '--verbose',
+             '--buildtool', 'rpmbuild', '--pkgcomparetool',
+             'rpmdiff', '--outputtool', 'json', '--keep-workspace', '--not-download-sources', '--continue',
+             '--non-interactive', '--comparepkgs-only', 'test_dir',
+             '--builds-nowait', '--build-tasks', '123456,654321',
+             '--build-retries', '2',
+             '--results-dir', '/tmp/rebase-helper',
+             '--builder-options=\"-v\"',
+        ]
         cli = CLI(arguments)
         for key, value in cli.args.__dict__.items():
             assert cli.args.__dict__[key] == conf[key]


### PR DESCRIPTION
Added new argument `--get-old-build-from-koji`, only available with **python 2** due to `koji` module still lacking **python 3** support. Hopefully not for long, see: https://pagure.io/koji/c/4f4639ec