### PR TITLE
Update openssl-libs to workaround curl issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   # don't start any services (mainly not the default ones)
   services:
   script:
+    - dnf -y upgrade openssl-libs
     - dnf -y install yum
     - dnf -y install $(cat test-deps-fedora.txt)
     - PYTEST_ADDOPTS="-m 'not optional'" tox

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -21,4 +21,4 @@ $(TEST_IMAGE):
 	git archive HEAD | $(DOCKER) run \
 		--cap-add=SYS_ADMIN --rm -i -v /build -w /build -e PY_COLORS=1 \
 		-e TOXENV="$(TOXENV)" -e PYTEST_ADDOPTS="$(PYTEST_ADDOPTS)" $(IMAGE) \
-		/bin/sh -c 'dnf -y install tar && tar -x && dnf -y install yum && dnf -y install $$(cat test-deps-fedora.txt) && tox'
+		/bin/sh -c 'dnf -y install tar && tar -x && dnf -y upgrade openssl-libs && dnf -y install yum && dnf -y install $$(cat test-deps-fedora.txt) && tox'


### PR DESCRIPTION
Installing yum updates (lib)curl, but keeps openssl-libs as is, which can trigger this bug in rawhide:
https://bugzilla.redhat.com/show_bug.cgi?id=1462184