### PR TITLE
Update a comment for old package rpm-python in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-# This can not be installed from pip, on Fedora you need to install rpm-python{,3}
+# This can not be installed from pip, on Fedora you need to install
+# python{2,3}-rpm package containing the module.
+# See: https://github.com/rpm-software-management/rpm/tree/master/python/rpm
 #rpm-python
 backports.lzma
 copr


### PR DESCRIPTION
This PR is to update `requirements.txt` correctly, and from below conversation.

> https://github.com/rebase-helper/rebase-helper/issues/285#issuecomment-312264180
> it used to be called rpm-python3, we should probably update the comment in requirements.txt
