### PR TITLE
Update KojiHelper for Koji 1.13

### DIFF
--- a/rebasehelper/build_tools/koji_tool.py
+++ b/rebasehelper/build_tools/koji_tool.py
@@ -24,6 +24,9 @@ import os
 import six
 import koji  # pylint: disable=import-error
 
+# unused import needed to prevent loading koji buildtool with Koji < 1.13
+import koji_cli.lib  # pylint: disable=import-error
+
 from rebasehelper.utils import KojiHelper
 from rebasehelper.logger import logger
 from rebasehelper.build_helper import BuildToolBase

--- a/rebasehelper/tests/test_utils.py
+++ b/rebasehelper/tests/test_utils.py
@@ -85,11 +85,11 @@ class TestConsoleHelper(object):
             with os.fdopen(sys.__stderr__.fileno(), 'w') as f:  # pylint:disable=no-member
                 f.write('test stderr')
 
-        stdout, stderr = ConsoleHelper.capture_output(
-            write, capture_stdout=True, capture_stderr=True)
+        with ConsoleHelper.Capturer(stdout=True, stderr=True) as capturer:
+            write()
 
-        assert stdout == 'test stdout'
-        assert stderr == 'test stderr'
+        assert capturer.stdout == 'test stdout'
+        assert capturer.stderr == 'test stderr'
 
 
 class TestDownloadHelper(object):


### PR DESCRIPTION
Koji 1.13 finally supports python3, but it's not packaged for Fedora yet, so we should probably wait before merging this.