### PR TITLE
Implement support for versioneers

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -41,6 +41,7 @@ from rebasehelper.exceptions import RebaseHelperError, CheckerNotFoundError
 from rebasehelper.build_log_analyzer import BuildLogAnalyzer, BuildLogAnalyzerMissingError
 from rebasehelper.results_store import results_store
 from rebasehelper.build_log_analyzer import BuildLogAnalyzerMakeError, BuildLogAnalyzerPatchError
+from rebasehelper.versioneer import versioneers_runner
 from rebasehelper import version
 
 
@@ -180,6 +181,14 @@ class Application(object):
             results_store.set_info_text('WARNING', 'Test suite is not enabled at build time.')
         #  create an object representing the rebased SPEC file
         self.rebase_spec_file = self.spec_file.copy(self.rebase_spec_file_path)
+
+        if not self.conf.sources:
+            self.conf.sources = versioneers_runner.run(self.conf.versioneer, self.spec_file.get_package_name())
+            if self.conf.sources:
+                logger.info("Determined latest upstream version '%s'", self.conf.sources)
+            else:
+                raise RebaseHelperError('Could not determine latest upstream version '
+                                        'and no SOURCES argument specified!')
 
         # Prepare rebased_sources_dir
         self.rebased_repo = self._prepare_rebased_repository(self.spec_file.patches, self.rebased_sources_dir)

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -33,6 +33,7 @@ from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.build_helper import Builder
 from rebasehelper.checker import checkers_runner
 from rebasehelper.output_tool import OutputTool
+from rebasehelper.versioneer import versioneers_runner
 from rebasehelper.utils import KojiHelper
 
 
@@ -123,6 +124,12 @@ class CLI(object):
             help="tool to use for formatting rebase output, defaults to %(default)s"
         )
         parser.add_argument(
+            "--versioneer",
+            choices=versioneers_runner.get_available_versioneers(),
+            default=versioneers_runner.get_default_versioneer(),
+            help="tool to use for determining latest upstream version, defaults to %(default)s"
+        )
+        parser.add_argument(
             "-w",
             "--keep-workspace",
             default=False,
@@ -146,6 +153,8 @@ class CLI(object):
         parser.add_argument(
             "sources",
             metavar='SOURCES',
+            nargs='?',
+            default=None,
             help="new upstream sources"
         )
         parser.add_argument(

--- a/rebasehelper/tests/test_cli.py
+++ b/rebasehelper/tests/test_cli.py
@@ -35,6 +35,7 @@ class TestCLI(object):
             'difftool': 'vimdiff',
             'pkgcomparetool': ['rpmdiff'],
             'outputtool': 'json',
+            'versioneer': 'anitya',
             'keep_workspace': True,
             'not_download_sources': True,
             'cont': True,

--- a/rebasehelper/tests/test_versioneer.py
+++ b/rebasehelper/tests/test_versioneer.py
@@ -26,6 +26,7 @@ from pkg_resources import parse_version
 
 from rebasehelper.versioneer import versioneers_runner
 from rebasehelper.versioneers.anitya_versioneer import AnityaVersioneer
+from rebasehelper.versioneers.pypi_versioneer import PyPIVersioneer
 
 
 class TestVersioneer(object):
@@ -40,4 +41,16 @@ class TestVersioneer(object):
     def test_anitya_versioneer(self, package, min_version):
         assert AnityaVersioneer.get_name() in versioneers_runner.versioneers
         version = versioneers_runner.run(AnityaVersioneer.get_name(), package)
+        assert parse_version(version) >= parse_version(min_version)
+
+    @pytest.mark.parametrize('package, min_version', [
+        ('python-m2r', '0.1.7'),
+        ('pyodbc', '4.0.17'),
+    ], ids=[
+        'python-m2r>=0.1.7',
+        'pyodbc>=4.0.17',
+    ])
+    def test_pypi_versioneer(self, package, min_version):
+        assert PyPIVersioneer.get_name() in versioneers_runner.versioneers
+        version = versioneers_runner.run(PyPIVersioneer.get_name(), package)
         assert parse_version(version) >= parse_version(min_version)

--- a/rebasehelper/tests/test_versioneer.py
+++ b/rebasehelper/tests/test_versioneer.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import pytest
+
+from pkg_resources import parse_version
+
+from rebasehelper.versioneer import versioneers_runner
+from rebasehelper.versioneers.anitya_versioneer import AnityaVersioneer
+
+
+class TestVersioneer(object):
+
+    @pytest.mark.parametrize('package, min_version', [
+        ('vim-go', 'v1.13'),
+        ('libtiff', '4.0.8'),
+    ], ids=[
+        'vim-go>=v1.13',
+        'libtiff>=4.0.8',
+    ])
+    def test_anitya_versioneer(self, package, min_version):
+        assert AnityaVersioneer.get_name() in versioneers_runner.versioneers
+        version = versioneers_runner.run(AnityaVersioneer.get_name(), package)
+        assert parse_version(version) >= parse_version(min_version)

--- a/rebasehelper/versioneer.py
+++ b/rebasehelper/versioneer.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import six
+import pkg_resources
+
+from rebasehelper.logger import logger
+
+
+class BaseVersioneer(object):
+    """Base class for a versioneer"""
+
+    DEFAULT = False
+
+    @classmethod
+    def is_default(cls):
+        """Checks if the versioneer is the default choice"""
+        raise NotImplementedError()
+
+    @classmethod
+    def get_name(cls):
+        """Returns the name of a versioneer"""
+        raise NotImplementedError()
+
+    @classmethod
+    def run(cls, package_name):
+        """
+        Runs a versioneer.
+
+        :param package_name: Name of a package
+        :return: Latest upstream version of a package
+        """
+        raise NotImplementedError()
+
+
+class VersioneersRunner(object):
+
+    def __init__(self):
+        self.versioneers = {}
+        for entrypoint in pkg_resources.iter_entry_points('rebasehelper.versioneers'):
+            try:
+                versioneer = entrypoint.load()
+            except ImportError:
+                # silently skip broken plugin
+                continue
+            try:
+                self.versioneers[versioneer.get_name()] = versioneer
+            except (AttributeError, NotImplementedError):
+                # silently skip broken plugin
+                continue
+
+    def get_available_versioneers(self):
+        """Returns a list of available versioneers"""
+        return [k for k, v in six.iteritems(self.versioneers)]
+
+    def get_default_versioneer(self):
+        """Returns default versioneer"""
+        default = [k for k, v in six.iteritems(self.versioneers) if v.is_default()]
+        return default[0] if default else None
+
+    def run(self, versioneer, package_name):
+        """
+        Runs specified versioneer.
+
+        :param versioneer: Name of a versioneer
+        :param package_name: Name of a package
+        :return: Latest upstream version of a package
+        """
+        logger.info("Running '%s' versioneer", versioneer)
+        return self.versioneers[versioneer].run(package_name)
+
+
+# Global instance of VersioneersRunner. It is enough to load it once per application run.
+versioneers_runner = VersioneersRunner()

--- a/rebasehelper/versioneers/__init__.py
+++ b/rebasehelper/versioneers/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>

--- a/rebasehelper/versioneers/anitya_versioneer.py
+++ b/rebasehelper/versioneers/anitya_versioneer.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import requests
+
+from pkg_resources import parse_version
+
+from rebasehelper.versioneer import BaseVersioneer
+
+
+class AnityaVersioneer(BaseVersioneer):
+
+    DEFAULT = True
+    NAME = 'anitya'
+
+    API_URL = 'https://release-monitoring.org/api/projects'
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
+
+    @classmethod
+    def get_name(cls):
+        return cls.NAME
+
+    @classmethod
+    def run(cls, package_name):
+        r = requests.get(cls.API_URL, params=dict(pattern=package_name))
+        if not r.ok:
+            return None
+        data = r.json()
+        try:
+            versions = [p['version'] for p in data['projects']]
+        except KeyError:
+            return None
+        # there can be multiple matching projects, just return the highest version of all of them
+        if versions:
+            return sorted(versions, key=parse_version, reverse=True)[0]
+        else:
+            return None

--- a/rebasehelper/versioneers/pypi_versioneer.py
+++ b/rebasehelper/versioneers/pypi_versioneer.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import re
+
+import requests
+
+from rebasehelper.versioneer import BaseVersioneer
+
+
+class PyPIVersioneer(BaseVersioneer):
+
+    DEFAULT = False
+    NAME = 'pypi'
+
+    API_URL = 'https://pypi.python.org/pypi'
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
+
+    @classmethod
+    def get_name(cls):
+        return cls.NAME
+
+    @classmethod
+    def run(cls, package_name):
+        r = requests.get('{}/{}/json'.format(cls.API_URL, package_name))
+        if not r.ok:
+            # try to strip python prefix
+            package_name = re.sub(r'^python[23]?-', '', package_name)
+            r = requests.get('{}/{}/json'.format(cls.API_URL, package_name))
+            if not r.ok:
+                return None
+        data = r.json()
+        try:
+            return data['info']['version']
+        except KeyError:
+            return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@
 backports.lzma
 copr
 pyquery
+requests
 six
 GitPython

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         ],
         'rebasehelper.versioneers': [
             'anitya = rebasehelper.versioneers.anitya_versioneer:AnityaVersioneer',
+            'pypi = rebasehelper.versioneers.pypi_versioneer:PyPIVersioneer',
         ]
     },
     setup_requires=[],

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'rebasehelper.build_tools',
         'rebasehelper.checkers',
         'rebasehelper.spec_hooks',
+        'rebasehelper.versioneers',
         'rebasehelper.tests',
     ],
     include_package_data=True,
@@ -65,6 +66,9 @@ setup(
         'rebasehelper.spec_hooks': [
             'typo_fix = rebasehelper.spec_hooks.typo_fix:TypoFixHook',
             'pypi_url_fix = rebasehelper.spec_hooks.pypi_url_fix:PyPIURLFixHook',
+        ],
+        'rebasehelper.versioneers': [
+            'anitya = rebasehelper.versioneers.anitya_versioneer:AnityaVersioneer',
         ]
     },
     setup_requires=[],


### PR DESCRIPTION
Versioneers are tools used for determining latest upstream version of a project.

* `anitya` versioneer queries https://release-monitoring.org
* `pypi` versioneer queries [Python Package Index](https://pypi.python.org/pypi)

This resolves issues #287 and #227.