### PR TITLE
Replace fedora:24 docker image with fedora:25

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,9 +11,9 @@ stages:
     - dnf -y install $(cat test-deps-fedora.txt)
     - PYTEST_ADDOPTS="-m 'not optional'" tox
 
-test:f24:
+test:f25:
   <<: *test_definition
-  image: fedora:24
+  image: fedora:25
 
 test:latest:
   <<: *test_definition

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: python
 services: docker
 env:
-    - DOCKER_IMAGE=fedora:24
+    - DOCKER_IMAGE=fedora:25
     - DOCKER_IMAGE=fedora:latest
     - DOCKER_IMAGE=fedora:rawhide
 install: true

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,4 +1,4 @@
-DOCKER_IMAGE ?= fedora:24 fedora:latest fedora:rawhide
+DOCKER_IMAGE ?= fedora:25 fedora:latest fedora:rawhide
 
 DOCKER := docker
 


### PR DESCRIPTION
Fedora 24 is EOL for over a week now and `fedora:latest` points to `fedora:26`.