### PR TITLE
Fix rpmdiff and abipkgdiff checkers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN dnf -y install \
   python3-devel \
   python2-rpm \
   python3-rpm \
+  python2-hawkey \
+  python3-hawkey \
   python2-tox \
   python3-tox \
   python-pip \

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,10 @@
 # python{2,3}-rpm package containing the module.
 # See: https://github.com/rpm-software-management/rpm/tree/master/python/rpm
 #rpm-python
+# This can not be installed from pip, on Fedora you need to install
+# python{2,3}-hawkey package containing the module
+# See: https://github.com/rpm-software-management/libdnf/tree/master/python/hawkey
+#hawkey
 backports.lzma
 copr
 pyquery


### PR DESCRIPTION
Fixes #301.

* rpmdiff
    * Skip debuginfo and debugsource packages
    * Do not traceback when matching new version (sub)package doesn't exist
* abipkgdiff
    * Use `split_nevra` from `hawkey` module for reliable parsing of package name
    * Find proper debuginfo package for each (sub)package and continue even if it doesn't exist, as abipkgdiff works fine without it - it just shows bare symbols only