### PR TITLE
Fix tests on Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,24 +1,30 @@
 stages:
-  - test
+    - test
 
 .test_template: &test_definition
-  stage: test
-  # don't start any services (mainly not the default ones)
-  services:
-  script:
-    - dnf -y upgrade openssl-libs
-    - dnf -y install yum
-    - dnf -y install $(cat test-deps-fedora.txt)
-    - PYTEST_ADDOPTS="-m 'not optional'" tox
+    stage: test
+    image: docker:latest
+    variables:
+        DOCKER_HOST: tcp://docker:2375
+        DOCKER_DRIVER: overlay
+    services:
+        - docker:dind
+    script:
+        - apk update
+        - apk add make git
+        - make PYTEST_ADDOPTS="-m 'not optional'" test-docker
 
 test:f25:
-  <<: *test_definition
-  image: fedora:25
+    <<: *test_definition
+    variables:
+        DOCKER_IMAGE: fedora:25
 
 test:latest:
-  <<: *test_definition
-  image: fedora:latest
+    <<: *test_definition
+    variables:
+        DOCKER_IMAGE: fedora:latest
 
 test:rawhide:
-  <<: *test_definition
-  image: fedora:rawhide
+    <<: *test_definition
+    variables:
+        DOCKER_IMAGE: fedora:rawhide

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -2,9 +2,11 @@ DOCKER_IMAGE ?= fedora:25 fedora:latest fedora:rawhide
 
 DOCKER := docker
 
+ifeq (,$(CI))
 # sudo is needed in case user is not member of docker group
 ifeq (,$(findstring docker,$(shell groups)))
 	DOCKER := sudo docker
+endif
 endif
 
 # escaping colon is broken in older versions of make,


### PR DESCRIPTION
Run tests on Gitlab CI the same way as on Travis CI, using `make test-docker`.