### PR TITLE
Add rpm-py-installer to install rpm-python from pip.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN mv RPM-GPG-KEY-fedora-28-primary /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-28-x86_
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-28-x86_64
 
 RUN dnf -y update
-# python2-pip is not available on F25.
 RUN dnf -y install \
   python2 \
   python2-devel \
@@ -25,6 +24,7 @@ RUN dnf -y install \
   python3-rpm \
   python2-tox \
   python3-tox \
+  # python2-pip is not available on F25.
   python-pip \
   python3-pip \
   python2-setuptools \
@@ -42,6 +42,8 @@ RUN dnf -y install \
   pkgdiff \
   dnf \
   dnf-plugins-core \
+  # needed by rpm-py-installer.
+  rpm-devel \
   && dnf clean all
 
 CMD ["/usr/bin/tox"]

--- a/setup.py
+++ b/setup.py
@@ -78,10 +78,8 @@ setup(
         ]
     },
     install_requires=[
-        # This can not be installed from pip, on Fedora you need to install
-        # python{2,3}-rpm package containing the module.
-        # See: https://github.com/rpm-software-management/rpm/tree/master/python/rpm
-        #'rpm-python',
+        # This installs the rpm package if not already present
+        'rpm-py-installer',
         'backports.lzma;python_version<"3.3"',
         'copr',
         'pyquery',


### PR DESCRIPTION
I think it's time to add `rpm-py-installer` to install `rpm-python` from pip, as I polished.

https://github.com/junaruga/rpm-py-installer

This fixes https://github.com/rebase-helper/rebase-helper/issues/285 .

I tested installing `rebase-helper` below cases.

```
(venv) $ pip install -e .
(venv) $ pip install .
$ sudo /usr/local/python-3.6.1/bin/pip3 install .
```

How do you think?

