### PR TITLE
Change pytest marker's defintions.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
     script:
         - apk update
         - apk add make git
-        - make PYTEST_ADDOPTS="-m 'not optional'" test-docker
+        - make PYTEST_ADDOPTS="-m 'standard or functional'" test-docker
 
 test:f25:
     <<: *test_definition

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ install: true
 before_script:
     - |
         if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
-            PYTEST_ADDOPTS="-m 1"
+            PYTEST_ADDOPTS="-m 'standard or functional or functional_long_running'"
         else
-            PYTEST_ADDOPTS="-m 'not optional'"
+            PYTEST_ADDOPTS="-m 'standard or functional'"
         fi
 script:
     - make PYTEST_ADDOPTS="${PYTEST_ADDOPTS}" test-docker

--- a/rebasehelper/tests/conftest.py
+++ b/rebasehelper/tests/conftest.py
@@ -38,3 +38,15 @@ def workdir(request, tmpdir_factory):
         for file_name in getattr(request.cls, 'TEST_FILES', []):
             shutil.copy(os.path.join(TEST_FILES_DIR, file_name), wd)
         yield wd
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        # item is an instance of Function class.
+        # https://github.com/pytest-dev/pytest/blob/master/_pytest/python.py
+        if 'functional_long_running' in item.keywords:
+            pass
+        elif 'functional' in item.fspath.strpath:
+            item.add_marker(pytest.mark.functional)
+        else:
+            item.add_marker(pytest.mark.standard)

--- a/rebasehelper/tests/functional/conftest.py
+++ b/rebasehelper/tests/functional/conftest.py
@@ -27,12 +27,6 @@ import pytest
 from rebasehelper.settings import REBASE_HELPER_RESULTS_DIR, REBASE_HELPER_DEBUG_LOG
 
 
-def pytest_collection_modifyitems(items):
-    for item in items:
-        if os.path.dirname(__file__) in item.fspath.strpath:
-            item.add_marker(pytest.mark.functional)
-
-
 def make_logs_report():
     logs = [
         REBASE_HELPER_DEBUG_LOG,

--- a/rebasehelper/tests/functional/test_rebase.py
+++ b/rebasehelper/tests/functional/test_rebase.py
@@ -52,7 +52,7 @@ class TestRebase(object):
             '1.12',
             {'deleted': None, 'modified': None, 'inapplicable': None},
         ),
-        pytest.mark.optional((
+        pytest.mark.functional_long_running((
             'libtiff',
             'https://src.fedoraproject.org/git/rpms/libtiff.git',
             '7b1dffc529cb934f8d30083e624f874a2df7c981',

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,11 @@
 envlist=py2,py3
 
 [pytest]
-addopts=-m 'not functional'
+addopts=-m standard
 markers=
+    standard: mark a test as a standard test.
     functional: mark a test as a functional test.
-    optional: mark a test as an optional test.
+    functional_long_running: mark a test as a long running functional test.
 
 [testenv]
 recreate=True


### PR DESCRIPTION
Related to https://github.com/rebase-helper/rebase-helper/issues/330#issuecomment-330282635

Now each test has normal, functional or functional_long_running marker. No duplication.
All test = normal + functional + functional_long_running.

marker: normal is default. and run on local.
marker: normal + functional is run in Travis pull-request, and the merge.
marker: normal + functional + functional_long_running (= -m "1") is run on Travis cron mode.

```
$ py.test -m 'normal' --setup-plan rebasehelper | grep "^        rebasehelper/tests" | wc -l
115

$ py.test -m 'functional' --setup-plan rebasehelper | grep "^        rebasehelper/tests" | wc -l
2

$ py.test -m 'functional_long_running' --setup-plan rebasehelper | grep "^        rebasehelper/tests" | wc -l
2

$ py.test -m 1 --setup-plan rebasehelper | grep "^        rebasehelper/tests" | wc -l
119
```

