### PR TITLE
Do not give tox virtualenvs access to sitepackages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ markers=
 
 [testenv]
 recreate=True
-sitepackages=True
 setenv=LANG=C.UTF-8
 passenv=PYTEST_ADDOPTS
 commands=


### PR DESCRIPTION
With `rpm-py-installer` all required packages can be installed from pip, so this is no longer necessary.