### PR TITLE
Reinitialize removed_patches in SpecFile constructor

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -133,6 +133,7 @@ class SpecFile(object):
         self._read_spec_content()
         # Load rpm information
         self.set_extra_version_separator('')
+        self.removed_patches = []
         self._update_data()
 
     def download_remote_sources(self):


### PR DESCRIPTION
`removed_patches` is a class attribute, and as such it persists between instances. So when `Application.run()` is called multiple times in the same script, `removed_patches` can contain data from previous runs, which is undesirable.