### PR TITLE
Add changelog template

### DIFF
--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -230,6 +230,11 @@ class CLI(object):
             default=None,
             help="new upstream sources"
         )
+        parser.add_argument(
+            "--changelog-entry",
+            default="- New upstream release %{version}",
+            help="text to use as changelog entry, can contain RPM macros, which will be expanded"
+        )
         return parser
 
     def __init__(self, args=None):

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -125,10 +125,11 @@ class SpecFile(object):
                         '%files',
                         '%changelog']
 
-    def __init__(self, path, sources_location='', download=True):
+    def __init__(self, path, changelog_entry, sources_location='', download=True):
         self.path = path
         self.download = download
         self.sources_location = sources_location
+        self.changelog_entry = changelog_entry
         #  Read the content of the whole SPEC file
         rpm.addMacro("_sourcedir", self.sources_location)
         self._read_spec_content()
@@ -1120,7 +1121,7 @@ class SpecFile(object):
         """
         if new_path:
             shutil.copy(self.path, new_path)
-        new_object = SpecFile(new_path, self.sources_location, self.download)
+        new_object = SpecFile(new_path, self.changelog_entry, self.sources_location, self.download)
         return new_object
 
     def save(self):
@@ -1298,7 +1299,8 @@ class SpecFile(object):
                                                                       name=GitHelper.get_user(),
                                                                       email=GitHelper.get_email(),
                                                                       evr=evr))
-        new_record.append('- New upstream release {rel}\n'.format(rel=self.get_version()))
+        self._update_data()
+        new_record.append(rpm.expandMacro(self.changelog_entry) + '\n')
         new_record.append('\n')
         return new_record
 

--- a/rebasehelper/tests/test_cli.py
+++ b/rebasehelper/tests/test_cli.py
@@ -51,6 +51,7 @@ class TestCLI(object):
             'builder_options': '\"-v\"',
             'get_old_build_from_koji': False,
             'color': 'auto',
+            'changelog_entry': 'Update to %{version}',
         }
         arguments = [
             'test-1.0.3.tar.gz', '--verbose',
@@ -61,6 +62,7 @@ class TestCLI(object):
              '--build-retries', '2',
              '--results-dir', '/tmp/rebase-helper',
              '--builder-options=\"-v\"',
+             '--changelog-entry', 'Update to %{version}',
         ]
         cli = CLI(arguments)
         for key, value in cli.args.__dict__.items():

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -64,7 +64,7 @@ class TestSpecFile(object):
 
     @pytest.fixture
     def spec_object(self, workdir):
-        sf = SpecFile(self.SPEC_FILE, workdir, download=False)
+        sf = SpecFile(self.SPEC_FILE, 'Update to %{version}', workdir, download=False)
         return sf
 
     def test_get_release(self, spec_object):


### PR DESCRIPTION
Resolves: #353 

Custom changelog entry can be set using --changelog-entry "message". RPM macros can be used to add version and other things (%{version}, %{name} etc.)
```

[root@9af0720655ba rubygem-afm]# python3 ../rebase-helper/rebase-helper.py --changelog-entry "Update to {VERSION}"
...
 
[root@9af0720655ba rubygem-afm]# diff rubygem-afm.spec rebase-helper-results/rebased-sources/rubygem-afm.spec
6c6
< Release: 6%{?dist}
---
> Release: 1%{?dist}
74a75,77
> * Tue Oct 17 2017 rebase-helper <rebase-helper@localhost.local> - 0.2.2-1
> Update to 0.2.2
```

@junaruga Which other options of formating would you like to have?