### PR TITLE
Fix to get git config user.name and user.email correctly.

### DIFF
--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -817,15 +817,17 @@ class GitHelper(object):
     @classmethod
     def get_user(cls):
         try:
-            return git.cmd.Git().config('--global', 'user.name', get=True, stdout_as_string=six.PY3)
+            return git.cmd.Git().config('user.name', get=True, stdout_as_string=six.PY3)
         except git.GitCommandError:
+            logger.warning("Failed to get configured git user name, using '%s'", cls.GIT_USER_NAME)
             return cls.GIT_USER_NAME
 
     @classmethod
     def get_email(cls):
         try:
-            return git.cmd.Git().config('--global', 'user.email', get=True, stdout_as_string=six.PY3)
+            return git.cmd.Git().config('user.email', get=True, stdout_as_string=six.PY3)
         except git.GitCommandError:
+            logger.warning("Failed to get configured git user email, using '%s'", cls.GIT_USER_EMAIL)
             return cls.GIT_USER_EMAIL
 
     @classmethod


### PR DESCRIPTION
This fixes https://github.com/rebase-helper/rebase-helper/issues/352

I added warnings for the case of failure to get user and email.
I added very simple unit tests.


## The case for the success to get user and email

```
(venv) $ rebase-helper

(venv) $ diff rubygem-byebug.spec rebase-helper-results/rebased-sources/rubygem-byebug.spec
126a127,129
> * Wed Oct 18 2017 Jun Aruga <jaruga@redhat.com> - 9.1.0-1
> - New upstream release 9.1.0
>
```

## The case for the failure to get user and email

```
(venv) $ rebase-helper
...
Faild to get Git user.name. Return the fallback value 'rebase-helper'
Faild to get Git user.email. Return the fallback value 'rebase-helper@localhost.local'
...
Faild to get Git user.name. Return the fallback value 'rebase-helper'
Faild to get Git user.email. Return the fallback value 'rebase-helper@localhost.local'
...

(venv) $ diff rubygem-byebug.spec rebase-helper-results/rebased-sources/rubygem-byebug.spec
126a127,129
> * Wed Oct 18 2017 rebase-helper <rebase-helper@localhost.local> - 9.1.0-1
> - New upstream release 9.1.0
> 
```
