### PR TITLE
Create SRPM builder tools

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -520,6 +520,9 @@ class Application(object):
                 build_dict['builds_nowait'] = self.conf.builds_nowait
                 build_dict['build_tasks'] = self.conf.build_tasks
                 build_dict['builder_options'] = self.conf.builder_options
+                build_dict['srpm_builder_options'] = self.conf.srpm_builder_options
+                build_dict['srpm_buildtool'] = self.conf.srpm_buildtool
+
                 patches = [x.get_path() for x in spec_object.get_patches()]
                 spec = spec_object.get_path()
                 sources = spec_object.get_sources()
@@ -553,7 +556,8 @@ class Application(object):
                     # Build finishes properly. Go out from while cycle
 
                     # Do not store rebase-helper internal data to the results
-                    for opt in ['builds_nowait', 'build_tasks', 'builder_options']:
+                    for opt in ['builds_nowait', 'build_tasks', 'builder_options',
+                                'srpm_builder_options', 'srpm_buildtool']:
                         build_dict.pop(opt)
                     results_store.set_build_data(version, build_dict)
                     break

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -517,6 +517,9 @@ class Application(object):
 
                 build_dict['name'] = pkg_name
                 build_dict['version'] = pkg_version
+                build_dict['builds_nowait'] = self.conf.builds_nowait
+                build_dict['build_tasks'] = self.conf.build_tasks
+                build_dict['builder_options'] = self.conf.builder_options
                 patches = [x.get_path() for x in spec_object.get_patches()]
                 spec = spec_object.get_path()
                 sources = spec_object.get_sources()
@@ -548,6 +551,10 @@ class Application(object):
                             if build_dict['rpm'] is None:
                                 return False
                     # Build finishes properly. Go out from while cycle
+
+                    # Do not store rebase-helper internal data to the results
+                    for opt in ['builds_nowait', 'build_tasks', 'builder_options']:
+                        build_dict.pop(opt)
                     results_store.set_build_data(version, build_dict)
                     break
 

--- a/rebasehelper/build_tools/copr_tool.py
+++ b/rebasehelper/build_tools/copr_tool.py
@@ -107,7 +107,7 @@ class CoprBuildTool(BuildToolBase):
                  'logs' -> list with absolute paths to build_logs
         """
         # build SRPM
-        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir)
+        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir, **kwargs)
         # build RPMs
         rpm_results_dir = os.path.join(results_dir, "RPM")
         os.makedirs(rpm_results_dir)

--- a/rebasehelper/build_tools/koji_tool.py
+++ b/rebasehelper/build_tools/koji_tool.py
@@ -154,7 +154,7 @@ class KojiBuildTool(BuildToolBase):
                  'logs' -> list with absolute paths to build_logs
         """
         # build SRPM
-        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir)
+        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir, **kwargs)
         # build RPMs
         rpm_results_dir = os.path.join(results_dir, "RPM")
         os.makedirs(rpm_results_dir)

--- a/rebasehelper/build_tools/mock_tool.py
+++ b/rebasehelper/build_tools/mock_tool.py
@@ -115,7 +115,7 @@ class MockBuildTool(BuildToolBase):
                  'logs' -> list with absolute paths to logs
         """
         # build SRPM
-        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir)
+        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir, **kwargs)
 
         # build RPMs
         rpm_results_dir = os.path.join(results_dir, "RPM")

--- a/rebasehelper/build_tools/rpmbuild_tool.py
+++ b/rebasehelper/build_tools/rpmbuild_tool.py
@@ -121,7 +121,7 @@ class RpmbuildBuildTool(BuildToolBase):
                  'logs' -> list with absolute paths to build_logs
         """
         # build SRPM
-        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir)
+        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir, **kwargs)
 
         # build RPMs
         rpm_results_dir = os.path.join(results_dir, "RPM")

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -31,7 +31,7 @@ from rebasehelper.version import VERSION
 from rebasehelper.application import Application
 from rebasehelper.logger import logger, LoggerHelper
 from rebasehelper.exceptions import RebaseHelperError
-from rebasehelper.build_helper import Builder
+from rebasehelper.build_helper import Builder, SRPMBuilder
 from rebasehelper.checker import checkers_runner
 from rebasehelper.output_tool import BaseOutputTool
 from rebasehelper.versioneer import versioneers_runner
@@ -127,6 +127,12 @@ class CLI(object):
             help="build tool to use, defaults to %(default)s"
         )
         parser.add_argument(
+            "--srpm-buildtool",
+            choices=SRPMBuilder.get_supported_tools(),
+            default=SRPMBuilder.get_default_tool(),
+            help="SRPM build tool to use, defaults to %(default)s"
+        )
+        parser.add_argument(
             "--pkgcomparetool",
             choices=checkers_runner.get_supported_tools(),
             default=checkers_runner.get_default_tools(),
@@ -204,6 +210,13 @@ class CLI(object):
             default=None,
             metavar="BUILDER_OPTIONS",
             help="enable arbitrary local builder option(s), enclose %(metavar)s in quotes "
+                 "and note that = before it is mandatory"
+        )
+        parser.add_argument(
+            "--srpm-builder-options",
+            default=None,
+            metavar="SRPM_BUILDER_OPTIONS",
+            help="enable arbitrary local srpm builder option(s), enclose %(metavar)s in quotes "
                  "and note that = before it is mandatory"
         )
         parser.add_argument(

--- a/rebasehelper/srpm_build_tools/__init__.py
+++ b/rebasehelper/srpm_build_tools/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>

--- a/rebasehelper/srpm_build_tools/mock_tool.py
+++ b/rebasehelper/srpm_build_tools/mock_tool.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os
+
+from rebasehelper.logger import logger
+from rebasehelper.build_helper import SRPMBuildToolBase
+from rebasehelper.utils import PathHelper
+from rebasehelper.utils import ProcessHelper
+
+
+class MockSRPMBuildTool(SRPMBuildToolBase):
+
+    CMD = "mock"
+    DEFAULT = False
+    logs = []
+
+    @classmethod
+    def get_build_tool_name(cls):
+        return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
+
+    @classmethod
+    def build_srpm(cls, spec, workdir, results_dir, srpm_builder_options):
+        """
+        Build SRPM using mock.
+
+        :param spec: abs path to SPEC file inside the rpmbuild/SPECS in workdir.
+        :param workdir: abs path to working directory with rpmbuild directory
+                        structure, which will be used as HOME dir.
+        :param results_dir: abs path to dir where the log should be placed.
+        :param srpm_builder_options: list of additional options for mock build tool(eg. '-r fedora-XX-x86_64')
+        :return: If build process ends successfully returns abs path
+                 to built SRPM, otherwise 'None'.
+        """
+        logger.info("Building SRPM")
+        spec_loc, spec_name = os.path.split(spec)
+        output = os.path.join(results_dir, "build.log")
+
+        path_to_sources = os.path.join(workdir, 'rpmbuild', 'SOURCES')
+
+        cmd = ['mock', '--old-chroot', '--buildsrpm']
+        if srpm_builder_options is not None:
+            cmd.extend(srpm_builder_options)
+        cmd.extend(['--spec', spec])
+        cmd.extend(['--sources', path_to_sources])
+        cmd.extend(['--resultdir', results_dir])
+
+        ret = ProcessHelper.run_subprocess_cwd_env(cmd,
+                                                   cwd=spec_loc,
+                                                   env={'HOME': workdir},
+                                                   output=output)
+
+        if ret != 0:
+            return None
+        else:
+            return PathHelper.find_first_file(workdir, '*.src.rpm')
+

--- a/rebasehelper/srpm_build_tools/rpmbuild_tool.py
+++ b/rebasehelper/srpm_build_tools/rpmbuild_tool.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os
+
+from rebasehelper.logger import logger
+from rebasehelper.build_helper import SRPMBuildToolBase
+from rebasehelper.utils import PathHelper
+from rebasehelper.utils import ProcessHelper
+
+
+class RpmbuildSRPMBuildTool(SRPMBuildToolBase):
+
+    CMD = "rpmbuild"
+    DEFAULT = True
+    logs = []
+
+    @classmethod
+    def get_build_tool_name(cls):
+        return cls.CMD
+
+    @classmethod
+    def is_default(cls):
+        return cls.DEFAULT
+
+    @classmethod
+    def build_srpm(cls, spec, workdir, results_dir, srpm_builder_options):
+        """
+        Build SRPM using rpmbuild.
+
+        :param spec: abs path to SPEC file inside the rpmbuild/SPECS in workdir.
+        :param workdir: abs path to working directory with rpmbuild directory
+                        structure, which will be used as HOME dir.
+        :param results_dir: abs path to dir where the log should be placed.
+        :param srpm_builder_options: list of additional options to rpmbuild.
+        :return: If build process ends successfully returns abs path
+                 to built SRPM, otherwise 'None'.
+        """
+        logger.info("Building SRPM")
+        spec_loc, spec_name = os.path.split(spec)
+        output = os.path.join(results_dir, "build.log")
+
+        cmd = ['rpmbuild', '-bs', spec_name]
+
+        if srpm_builder_options is not None:
+            cmd.extend(srpm_builder_options)
+
+        ret = ProcessHelper.run_subprocess_cwd_env(cmd,
+                                                   cwd=spec_loc,
+                                                   env={'HOME': workdir},
+                                                   output=output)
+
+        if ret != 0:
+            return None
+        else:
+            return PathHelper.find_first_file(workdir, '*.src.rpm')
+

--- a/rebasehelper/tests/test_cli.py
+++ b/rebasehelper/tests/test_cli.py
@@ -52,6 +52,8 @@ class TestCLI(object):
             'get_old_build_from_koji': False,
             'color': 'auto',
             'changelog_entry': 'Update to %{version}',
+            'srpm_builder_options': '\"-r fedora-26-x86_64\"',
+            'srpm_buildtool': 'mock',
         }
         arguments = [
             'test-1.0.3.tar.gz', '--verbose',
@@ -63,6 +65,8 @@ class TestCLI(object):
              '--results-dir', '/tmp/rebase-helper',
              '--builder-options=\"-v\"',
              '--changelog-entry', 'Update to %{version}',
+             '--srpm-builder-options=\"-r fedora-26-x86_64\"',
+             '--srpm-buildtool', 'mock',
         ]
         cli = CLI(arguments)
         for key, value in cli.args.__dict__.items():

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     packages=[
         'rebasehelper',
         'rebasehelper.build_tools',
+        'rebasehelper.srpm_build_tools',
         'rebasehelper.checkers',
         'rebasehelper.spec_hooks',
         'rebasehelper.output_tools',
@@ -89,6 +90,10 @@ setup(
             'mock = rebasehelper.build_tools.mock_tool:MockBuildTool',
             'koji = rebasehelper.build_tools.koji_tool:KojiBuildTool',
             'copr = rebasehelper.build_tools.copr_tool:CoprBuildTool',
+        ],
+        'rebasehelper.srpm_build_tools': [
+            'rpmbuild = rebasehelper.srpm_build_tools.rpmbuild_tool:RpmbuildSRPMBuildTool',
+            'mock = rebasehelper.srpm_build_tools.mock_tool:MockSRPMBuildTool',
         ],
         'rebasehelper.checkers': [
             'rpmdiff = rebasehelper.checkers.rpmdiff_tool:RpmDiffTool',


### PR DESCRIPTION
Pass builder_options values to `build_dict{}`

Implement `SRPMBuilderTools` to allow users to use mock for source rpms creation.

Implement `SRPM options` to allow users to set configuration for building source rpms.

Resolves: #366 #361