### PR TITLE
Run unit tests for specified test file and the case.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ markers=
     standard: mark a test as a standard test.
     functional: mark a test as a functional test.
     functional_long_running: mark a test as a long running functional test.
+testpaths=rebasehelper/tests
 
 [testenv]
 recreate=True
@@ -14,8 +15,8 @@ setenv=LANG=C.UTF-8
 passenv=PYTEST_ADDOPTS
 commands=
     pylint --rcfile=pylintrc rebasehelper
-    py.test --verbose --color=yes rebasehelper/tests \
-            --cov rebasehelper --cov-report html --cov-report term
+    py.test --verbose --color=yes \
+            {posargs:--cov rebasehelper --cov-report html --cov-report term}
 deps=
     -rtest-requirements.txt
 


### PR DESCRIPTION
I want to run specified test case for unit tests.
This feature is beneficial when especially we have to run the case repeatedly such as fixing bug,

`{postargs}` helps the situation.
> http://tox.readthedocs.io/en/latest/example/general.html
> tox -- -x tests/test_something.py

The result is like this.
If the argument is not specified, the default value foo in `{posargs:foo}` is used.

```
$ tox -e py3 -- rebasehelper/tests/test_utils.py::TestConsoleHelper::test_get_message[no]
...
collected 1 item                                                                              

rebasehelper/tests/test_utils.py::TestConsoleHelper::test_get_message[no] PASSED

================================== 1 passed in 0.22 seconds ==================================
__________________________________________ summary ___________________________________________
  py3: commands succeeded
  congratulations :)
```

Also the total running time is improved a little bit.

Before the modification

```
$ time tox -e py3
...
real  1m59.707s
user  0m43.769s
sys 0m2.736s
```

After the modification

```
$ time tox -e py3
...
real  1m51.653s
user  0m44.125s
sys 0m2.782s
```


