### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,5 @@ test:
 	tox
 
 
-test-docker:
+test-docker: clean
 	make -f Makefile.docker test

--- a/rebase-helper.bash.in
+++ b/rebase-helper.bash.in
@@ -25,7 +25,7 @@ _rebase-helper()
     local rh_choices=@RH_CHOICES@
     local rh_extensions=@RH_EXTENSIONS@
 
-    local cur prev opt
+    local cur prev idx
 
     _get_comp_words_by_ref -n = cur prev
     _split_longopt

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -168,9 +168,8 @@ class CLI(object):
         )
         parser.add_argument(
             "--color",
-            default='auto',
-            dest='color',
             choices=['always', 'never', 'auto'],
+            default='auto',
             help="colorize the output, defaults to %(default)s"
         )
         parser.add_argument(


### PR DESCRIPTION
* Clean up before running `test-docker` make target
* Fix variable name in `rebase-helper.bash.in`
* Remove redundant dest argument of `--color` option