### PR TITLE
Update to skip rpmbuild test when it is run by non-root user.

### DIFF
--- a/rebasehelper/tests/functional/test_rebase.py
+++ b/rebasehelper/tests/functional/test_rebase.py
@@ -41,7 +41,10 @@ class TestRebase(object):
         return repo
 
     @pytest.mark.parametrize('buildtool', [
-        'rpmbuild',
+         pytest.mark.skipif(
+             os.geteuid() != 0,
+             reason='requires superuser privileges')
+         ('rpmbuild'),
         'mock',
     ])
     @pytest.mark.parametrize('package, url, commit, version, patches', [


### PR DESCRIPTION
This fixes https://github.com/rebase-helper/rebase-helper/issues/356 .

This PR is inspired from https://docs.pytest.org/en/latest/skipping.html .
> def test_function():
>     if not valid_config():
>         pytest.skip("unsupported configuration")

The result is like this.

```
$ whoami
jaruga

$ tox -e py3 -- -m 1 rebasehelper/tests/functional/test_rebase.py
...
rebasehelper/tests/functional/test_rebase.py::TestRebase::test_rebase[vim-go-1.11-2=>1.12-rpmbuild] SKIPPED
rebasehelper/tests/functional/test_rebase.py::TestRebase::test_rebase[vim-go-1.11-2=>1.12-mock] PASSED
rebasehelper/tests/functional/test_rebase.py::TestRebase::test_rebase[libtiff-4.0.7-5=>4.0.8-rpmbuild] SKIPPED
rebasehelper/tests/functional/test_rebase.py::TestRebase::test_rebase[libtiff-4.0.7-5=>4.0.8-mock] PASSED   

=========================== 2 passed, 2 skipped in 344.34 seconds ============================
__________________________________________ summary ___________________________________________
  py3: commands succeeded
  congratulations :)
```

How?

