### PR TITLE
Merge CLI arguments with config arguments

### DIFF
--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -34,6 +34,7 @@ from rebasehelper.application import Application
 from rebasehelper.logger import logger, LoggerHelper
 from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.utils import KojiHelper, ConsoleHelper
+from rebasehelper.config import Conf
 
 
 class CustomHelpFormatter(argparse.HelpFormatter):
@@ -163,14 +164,17 @@ class CliHelper(object):
                 raise RebaseHelperError('Wrong format of --builder-options. It must be in the following form:'
                                         ' --builder-options="--desired-builder-option".')
             cli = CLI()
-            if cli.version:
+            if hasattr(cli, 'version'):
                 logger.info(VERSION)
                 sys.exit(0)
-            ConsoleHelper.use_colors = ConsoleHelper.should_use_colors(cli)
-            execution_dir, results_dir, debug_log_file = Application.setup(cli)
-            if not cli.verbose:
+
+            conf = Conf(getattr(cli, 'conf', None))
+            conf.merge(cli)
+            ConsoleHelper.use_colors = ConsoleHelper.should_use_colors(conf)
+            execution_dir, results_dir, debug_log_file = Application.setup(conf)
+            if not conf.verbose:
                 handler.setLevel(logging.INFO)
-            app = Application(cli, execution_dir, results_dir, debug_log_file)
+            app = Application(conf, execution_dir, results_dir, debug_log_file)
             app.run()
         except KeyboardInterrupt:
             logger.info('\nInterrupted by user')

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -27,15 +27,12 @@ import sys
 
 import six
 
+from rebasehelper.options import OPTIONS, traverse_options
 from rebasehelper.constants import PROGRAM_DESCRIPTION, NEW_ISSUE_LINK
 from rebasehelper.version import VERSION
 from rebasehelper.application import Application
 from rebasehelper.logger import logger, LoggerHelper
 from rebasehelper.exceptions import RebaseHelperError
-from rebasehelper.build_helper import Builder, SRPMBuilder
-from rebasehelper.checker import checkers_runner
-from rebasehelper.output_tool import BaseOutputTool
-from rebasehelper.versioneer import versioneers_runner
 from rebasehelper.utils import KojiHelper, ConsoleHelper
 
 
@@ -117,163 +114,29 @@ class CLI(object):
     def build_parser():
         parser = CustomArgumentParser(description=PROGRAM_DESCRIPTION,
                                       formatter_class=CustomHelpFormatter)
-        parser.add_argument(
-            "--version",
-            default=False,
-            action="store_true",
-            help="show rebase-helper version and exit"
-        )
-        parser.add_argument(
-            "-v",
-            "--verbose",
-            default=False,
-            action="store_true",
-            help="be more verbose (recommended)"
-        )
+
         group = parser.add_mutually_exclusive_group()
-        group.add_argument(
-            "-b",
-            "--build-only",
-            default=False,
-            action="store_true",
-            help="only build SRPM and RPMs"
-        )
-        group.add_argument(
-            "--comparepkgs-only",
-            default=False,
-            dest="comparepkgs",
-            metavar="COMPAREPKGS_DIR",
-            help="compare already built packages, %(metavar)s must be a directory "
-                 "with the following structure: <dir_name>/{old,new}/RPM"
-        )
-        group.add_argument(
-            "-p",
-            "--patch-only",
-            default=False,
-            action="store_true",
-            help="only apply patches"
-        )
-        parser.add_argument(
-            "--buildtool",
-            choices=Builder.get_supported_tools(),
-            default=Builder.get_default_tool(),
-            help="build tool to use, defaults to %(default)s"
-        )
-        parser.add_argument(
-            "--srpm-buildtool",
-            choices=SRPMBuilder.get_supported_tools(),
-            default=SRPMBuilder.get_default_tool(),
-            help="SRPM build tool to use, defaults to %(default)s"
-        )
-        parser.add_argument(
-            "--pkgcomparetool",
-            choices=checkers_runner.get_supported_tools(),
-            default=checkers_runner.get_default_tools(),
-            type=lambda s: s.split(','),
-            help="set of tools to use for package comparison, defaults to %(default)s"
-        )
-        parser.add_argument(
-            "--outputtool",
-            choices=BaseOutputTool.get_supported_tools(),
-            default=BaseOutputTool.get_default_tool(),
-            help="tool to use for formatting rebase output, defaults to %(default)s"
-        )
-        parser.add_argument(
-            "--versioneer",
-            choices=versioneers_runner.get_available_versioneers(),
-            default=None,
-            help="tool to use for determining latest upstream version"
-        )
-        parser.add_argument(
-            "--not-download-sources",
-            default=False,
-            action="store_true",
-            help="do not download sources"
-        )
-        parser.add_argument(
-            "-w",
-            "--keep-workspace",
-            default=False,
-            action="store_true",
-            help="do not remove workspace directory after finishing"
-        )
-        parser.add_argument(
-            "-c",
-            "--continue",
-            default=False,
-            action="store_true",
-            dest='cont',
-            help="continue previously interrupted rebase"
-        )
-        parser.add_argument(
-            "--color",
-            choices=['always', 'never', 'auto'],
-            default='auto',
-            help="colorize the output, defaults to %(default)s"
-        )
-        parser.add_argument(
-            "--disable-inapplicable-patches",
-            default=False,
-            action="store_true",
-            dest='disable_inapplicable_patches',
-            help="disable inapplicable patches in rebased SPEC file"
-        )
-        parser.add_argument(
-            "--non-interactive",
-            default=False,
-            action="store_true",
-            dest='non_interactive',
-            help="do not interact with user"
-        )
-        parser.add_argument(
-            "--build-tasks",
-            dest="build_tasks",
-            metavar="OLD_TASK,NEW_TASK",
-            type=lambda s: s.split(','),
-            help="comma-separated remote build task ids"
-        )
-        parser.add_argument(
-            "--builds-nowait",
-            default=False,
-            action="store_true",
-            help="do not wait for remote builds to finish"
-        )
-        parser.add_argument(
-            "--builder-options",
-            default=None,
-            metavar="BUILDER_OPTIONS",
-            help="enable arbitrary local builder option(s), enclose %(metavar)s in quotes "
-                 "and note that = before it is mandatory"
-        )
-        parser.add_argument(
-            "--srpm-builder-options",
-            default=None,
-            metavar="SRPM_BUILDER_OPTIONS",
-            help="enable arbitrary local srpm builder option(s), enclose %(metavar)s in quotes "
-                 "and note that = before it is mandatory"
-        )
-        parser.add_argument(
-            "--results-dir",
-            help="directory where rebase-helper output will be stored"
-        )
-        parser.add_argument(
-            "--get-old-build-from-koji",
-            default=False,
-            action="store_true",
-            help="do not build old sources, download latest build from Koji instead"
-        )
-        parser.add_argument(
-            "sources",
-            metavar='SOURCES',
-            nargs='?',
-            default=None,
-            help="new upstream sources"
-        )
-        parser.add_argument(
-            "--changelog-entry",
-            default="- New upstream release %{version}",
-            help="text to use as changelog entry, can contain RPM macros, which will be expanded"
-        )
+        current_group = 0
+        for option in traverse_options(OPTIONS):
+            option_kwargs = dict(option)
+            for key in ("group", "default", "name"):
+                if key in option_kwargs:
+                    del option_kwargs[key]
+
+            if "group" in option:
+                if current_group != option["group"]:
+                    current_group = option["group"]
+                    group = parser.add_mutually_exclusive_group()
+                actions_container = group
+            else:
+                actions_container = parser
+
+            # default is set to SUPPRESS to prevent arguments which were not specified on command line from being
+            # added to namespace. This allows rebase-helper to determine which arguments are used with their
+            # default value. This is later used for merging CLI arguments with config.
+            actions_container.add_argument(*option["name"], action=CustomAction, default=argparse.SUPPRESS,
+                                           actual_default=option.get("default"), **option_kwargs)
+
         return parser
 
     def __init__(self, args=None):

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -50,10 +50,42 @@ class CustomHelpFormatter(argparse.HelpFormatter):
         return re.sub(r' ((SRPM_)?BUILDER_OPTIONS)', r'=\1', text)
 
     def _expand_help(self, action):
+        action.default = getattr(action, 'actual_default', None)
         if isinstance(action.default, list):
             default_str = ','.join([str(c) for c in action.default])
             action.default = default_str
         return super(CustomHelpFormatter, self)._expand_help(action)
+
+
+class CustomAction(argparse.Action):
+    def __init__(self, option_strings,
+                 switch=False,
+                 actual_default=None,
+                 dest=None,
+                 default=None,
+                 nargs=None,
+                 required=False,
+                 type=None,
+                 metavar=None,
+                 help=None,
+                 choices=None):
+
+        super(CustomAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            required=required,
+            metavar=metavar,
+            type=type,
+            help=help,
+            choices=choices)
+
+        self.switch = switch
+        self.nargs = 0 if self.switch else nargs
+        self.actual_default = actual_default
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, True if self.switch else values)
 
 
 class CustomArgumentParser(argparse.ArgumentParser):

--- a/rebasehelper/config.py
+++ b/rebasehelper/config.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os.path
+
+from six.moves import configparser
+
+from rebasehelper.options import OPTIONS, traverse_options
+from rebasehelper.constants import CONFIG_FILE
+
+
+class Conf:
+    def __init__(self, config_file):
+        self.path_to_config = self.get_conf_path(config_file)
+        self.config = self.get_config()
+
+    @staticmethod
+    def get_conf_path(config_file):
+        if not config_file:
+            path = os.environ.get('XDG_CONFIG_HOME', os.path.expandvars('$HOME/.config'))
+            config_file = os.path.join(path, CONFIG_FILE)
+            return config_file
+        return os.path.abspath(config_file)
+
+    def get_config(self):
+        conf = {}
+        if os.path.isfile(self.path_to_config):
+            config = configparser.ConfigParser()
+            config.read(self.path_to_config)
+            for section in config.sections():
+                conf.update({k.replace('-', '_'): v for k, v in config.items(section)})
+
+        return conf
+
+    def merge(self, cli):
+        self.config.update(vars(cli.args))
+
+        for option in traverse_options(OPTIONS):
+            args = [n.lstrip('-').replace('-', '_') for n in option['name'] if n.startswith('--')]
+            if args:
+                dest = args[0]
+
+            if dest and dest not in self.config:
+                self.config[dest] = option.get('default')
+
+    def __getattr__(self, name):
+        return self.config.get(name)

--- a/rebasehelper/constants.py
+++ b/rebasehelper/constants.py
@@ -22,3 +22,4 @@
 
 PROGRAM_DESCRIPTION = "Tool to help package maintainers rebase their packages to the latest upstream version"
 NEW_ISSUE_LINK = 'https://github.com/rebase-helper/rebase-helper/issues/new'
+CONFIG_FILE = "rebase-helper.cfg"

--- a/rebasehelper/options.py
+++ b/rebasehelper/options.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+from rebasehelper.build_helper import Builder, SRPMBuilder
+from rebasehelper.checker import checkers_runner
+from rebasehelper.output_tool import BaseOutputTool
+from rebasehelper.versioneer import versioneers_runner
+
+OPTIONS = [
+    {
+        "name": ("--version",),
+        "default": False,
+        "switch": True,
+        "help": "show rebase-helper version and exit",
+    },
+    {
+        "name": ("-v", "--verbose"),
+        "default": False,
+        "switch": True,
+        "help": "be more verbose (recommended)",
+    },
+    [
+        {
+            "name": ("-b", "--build-only"),
+            "default": False,
+            "switch": True,
+            "help": "only build SRPM and RPMs",
+        },
+        {
+            "name": ("--comparepkgs-only",),
+            "default": False,
+            "dest": "comparepkgs",
+            "metavar": "COMPAREPKGS_DIR",
+            "help": "compare already built packages, %(metavar)s must be a directory "
+                    "with the following structure: <dir_name>/{old,new}/RPM",
+        },
+        {
+            "name": ("-p", "--patch-only"),
+            "default": False,
+            "switch": True,
+            "help": "only apply patches",
+        },
+    ],
+    {
+        "name": ("--buildtool",),
+        "choices": Builder.get_supported_tools(),
+        "default": Builder.get_default_tool(),
+        "help": "build tool to use, defaults to %(default)s",
+    },
+    {
+        "name": ("--srpm-buildtool",),
+        "choices": SRPMBuilder.get_supported_tools(),
+        "default": SRPMBuilder.get_default_tool(),
+        "help": "SRPM build tool to use, defaults to %(default)s",
+    },
+    {
+        "name": ("--pkgcomparetool",),
+        "choices": checkers_runner.get_supported_tools(),
+        "default": checkers_runner.get_default_tools(),
+        "type": lambda s: s.split(','),
+        "help": "set of tools to use for package comparison, defaults to %(default)s",
+    },
+    {
+        "name": ("--outputtool",),
+        "choices": BaseOutputTool.get_supported_tools(),
+        "default": BaseOutputTool.get_default_tool(),
+        "help": "tool to use for formatting rebase output, defaults to %(default)s",
+    },
+    {
+        "name": ("--versioneer",),
+        "choices": versioneers_runner.get_available_versioneers(),
+        "default": None,
+        "help": "tool to use for determining latest upstream version",
+    },
+    {
+        "name": ("--not-download-sources",),
+        "default": False,
+        "switch": True,
+        "help": "do not download sources",
+    },
+    {
+        "name": ("-w", "--keep-workspace"),
+        "default": False,
+        "switch": True,
+        "help": "do not remove workspace directory after finishing",
+    },
+    {
+        "name": ("-c", "--continue"),
+        "default": False,
+        "switch": True,
+        "dest": "cont",
+        "help": "continue previously interrupted rebase",
+    },
+    {
+        "name": ("--color",),
+        "choices": ["always", "never", "auto"],
+        "default": "auto",
+        "help": "colorize the output, defaults to %(default)s",
+    },
+    {
+        "name": ("--disable-inapplicable-patches",),
+        "default": False,
+        "switch": True,
+        "dest": "disable_inapplicable_patches",
+        "help": "disable inapplicable patches in rebased SPEC file",
+    },
+    {
+        "name": ("--non-interactive",),
+        "default": False,
+        "switch": True,
+        "dest": "non_interactive",
+        "help": "do not interact with user",
+    },
+    {
+        "name": ("--build-tasks",),
+        "dest": "build_tasks",
+        "metavar": "OLD_TASK,NEW_TASK",
+        "type": lambda s: s.split(','),
+        "help": "comma-separated remote build task ids",
+    },
+    {
+        "name": ("--builds-nowait",),
+        "default": False,
+        "switch": True,
+        "help": "do not wait for remote builds to finish",
+    },
+    {
+        "name": ("--builder-options",),
+        "default": None,
+        "metavar": "BUILDER_OPTIONS",
+        "help": "enable arbitrary local builder option(s), enclose %(metavar)s in quotes "
+                "and note that = before it is mandatory",
+    },
+    {
+        "name": ("--srpm-builder-options",),
+        "default": None,
+        "metavar": "SRPM_BUILDER_OPTIONS",
+        "help": "enable arbitrary local srpm builder option(s), enclose %(metavar)s in quotes "
+                "and note that = before it is mandatory",
+    },
+    {
+        "name": ("--build-retries",),
+        "default": 2,
+        "help": "number of retries of a failed build, defaults to %(default)d",
+        "type": int,
+    },
+    {
+        "name": ("--results-dir",),
+        "help": "directory where rebase-helper output will be stored",
+    },
+    {
+        "name": ("--get-old-build-from-koji",),
+        "default": False,
+        "switch": True,
+        "help": "do not build old sources, download latest build from Koji instead",
+    },
+    {
+        "name": ("sources",),
+        "metavar": "SOURCES",
+        "nargs": "?",
+        "default": None,
+        "help": "new upstream sources",
+    },
+    {
+        "name": ("--changelog-entry",),
+        "default": "- New upstream release %{version}",
+        "help": "text to use as changelog entry, can contain RPM macros, which will be expanded",
+    },
+]
+
+
+def traverse_options(options):
+    group_index = 0
+    for opt in options:
+        if isinstance(opt, list):
+            for inner_opt in opt:
+                yield dict(group=group_index, **inner_opt)
+            group_index += 1
+        else:
+            yield opt

--- a/rebasehelper/options.py
+++ b/rebasehelper/options.py
@@ -185,6 +185,10 @@ OPTIONS = [
         "default": "- New upstream release %{version}",
         "help": "text to use as changelog entry, can contain RPM macros, which will be expanded",
     },
+    {
+        "name": ("--conf",),
+        "help": "custom path to configuration file",
+    },
 ]
 
 

--- a/rebasehelper/tests/functional/test_rebase.py
+++ b/rebasehelper/tests/functional/test_rebase.py
@@ -28,6 +28,7 @@ import pytest
 import unidiff
 
 from rebasehelper.cli import CLI
+from rebasehelper.config import Conf
 from rebasehelper.application import Application
 from rebasehelper.settings import REBASE_HELPER_RESULTS_DIR
 
@@ -98,8 +99,10 @@ class TestRebase(object):
             '--color=always',
             version
         ])
-        execution_dir, results_dir, debug_log_file = Application.setup(cli)
-        app = Application(cli, execution_dir, results_dir, debug_log_file)
+        conf = Conf(getattr(cli, 'conf', None))
+        conf.merge(cli)
+        execution_dir, results_dir, debug_log_file = Application.setup(conf)
+        app = Application(conf, execution_dir, results_dir, debug_log_file)
         app.run()
         with open(os.path.join(REBASE_HELPER_RESULTS_DIR, 'report.json')) as f:
             report = json.load(f)

--- a/rebasehelper/tests/test_application.py
+++ b/rebasehelper/tests/test_application.py
@@ -23,6 +23,7 @@
 import os
 
 from rebasehelper.cli import CLI
+from rebasehelper.config import Conf
 from rebasehelper.application import Application
 from rebasehelper import settings
 
@@ -98,8 +99,10 @@ class TestApplication(object):
             'results_dir': os.path.join(workdir, settings.REBASE_HELPER_RESULTS_DIR)}
 
         cli = CLI(self.cmd_line_args)
-        execution_dir, results_dir, debug_log_file = Application.setup(cli)
-        app = Application(cli, execution_dir, results_dir, debug_log_file)
+        conf = Conf(getattr(cli, 'conf', None))
+        conf.merge(cli)
+        execution_dir, results_dir, debug_log_file = Application.setup(conf)
+        app = Application(conf, execution_dir, results_dir, debug_log_file)
         app.prepare_sources()
         for key, val in app.kwargs.items():
             if key in expected_dict:

--- a/rebasehelper/tests/test_conf.py
+++ b/rebasehelper/tests/test_conf.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os
+import pytest
+import six
+
+from rebasehelper.cli import CLI
+from rebasehelper.config import Conf
+
+
+class TestConfig(object):
+    CONF_FILE = 'test_conf.cfg'
+
+    @pytest.fixture
+    def config_file(self, conf_args):
+        config = six.moves.configparser.ConfigParser()
+        config.add_section('Section1')
+        for key, value in six.iteritems(conf_args):
+            config.set('Section1', key, value)
+        with open(self.CONF_FILE, 'w') as configfile:
+            config.write(configfile)
+
+        return os.path.abspath(self.CONF_FILE)
+
+    @pytest.mark.parametrize('conf_args', [
+        {
+            'changelog-entry': 'Updated to',
+            'versioneer': 'pypi',
+        },
+        {},
+    ], ids=[
+        'configured',
+        'empty',
+    ])
+    def test_get_config(self, conf_args, config_file):
+        conf = Conf(config_file)
+        expected_result = {k.replace('-', '_'): v for k, v in six.iteritems(conf_args)}
+        assert expected_result == conf.config
+
+    @pytest.mark.parametrize('cli_args, conf_args, merged', [
+        (
+            [
+                '--changelog-entry', 'Version set to',
+                '--buildtool', 'rpmbuild',
+            ],
+            {
+                'changelog-entry': 'Updated to ',
+                'versioneer': 'pypi',
+            },
+            {
+                'changelog-entry': 'Version set to',
+                'versioneer': 'pypi',
+                'buildtool': 'rpmbuild',
+                'color': 'auto',
+            },
+        ),
+    ], ids=[
+            'CLI with config',
+    ])
+    def test_merge(self, cli_args, merged, config_file):
+        expected_result = {k.replace('-', '_'): v for k, v in six.iteritems(merged)}
+        cli = CLI(cli_args)
+        conf = Conf(config_file)
+        conf.merge(cli)
+        # True if expected_result is a subset of conf.config
+        assert six.viewitems(expected_result) <= six.viewitems(conf.config)


### PR DESCRIPTION
There is now a parameter --conf to set path to a configfile.
If the path is not set, $HOME/.config/rebase-helper is used by default.

Config lines starting with # are ignored.
CLI arguments have priority over config arguments if they are set manually.
If there is not a certain config argument, CLI argument is used.

Resolves: #294 