### PR TITLE
Run tests on F26, F27 and rawhide

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,10 @@ stages:
         - apk add make git python py-setuptools
         - make PYTEST_ADDOPTS="-m 'standard or functional'" test-docker
 
-test:f25:
+test:f26:
     <<: *test_definition
     variables:
-        DOCKER_IMAGE: fedora:25
+        DOCKER_IMAGE: fedora:26
 
 test:latest:
     <<: *test_definition

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: python
 services: docker
 env:
-    - DOCKER_IMAGE=fedora:25
+    - DOCKER_IMAGE=fedora:26
     - DOCKER_IMAGE=fedora:latest
     - DOCKER_IMAGE=fedora:rawhide
 before_install:

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,4 +1,4 @@
-DOCKER_IMAGE ?= fedora:25 fedora:latest fedora:rawhide
+DOCKER_IMAGE ?= fedora:26 fedora:latest fedora:rawhide
 
 DOCKER := docker
 


### PR DESCRIPTION
`fedora:latest` now points to F27, so it is time to move from `fedora:25` to `fedora:26`.