### PR TITLE
Add parentheses to format error message properly

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -349,8 +349,8 @@ class Application(object):
         try:
             archive = Archive(archive_path)
         except NotImplementedError as ni_e:
-            raise RebaseHelperError('%s. Supported archives are %s' % six.text_type(ni_e),
-                                    Archive.get_supported_archives())
+            raise RebaseHelperError('%s. Supported archives are %s' % (six.text_type(ni_e),
+                                    Archive.get_supported_archives()))
 
         try:
             archive.extract_archive(destination)


### PR DESCRIPTION
When the exception was raised, it resulted in an error: "not enough arguments for format string" because of the missing parentheses
