### PR TITLE
Handle SSL Exception when kerberos ticket is missing

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -584,9 +584,10 @@ class Application(object):
                     msg = 'Building {} RPM packages failed; see {} for more information'.format(version, e.logfile)
                 raise RebaseHelperError(msg, logfiles=builder.get_logs().get('logs'))
 
-            except Exception:
+            except Exception as e:
                 raise RebaseHelperError('Building package failed with unknown reason. '
-                                        'Check all available log files.')
+                                        'The error reported is "{}". '
+                                        'Check all available log files.'.format(six.text_type(e)))
 
         if self.conf.builds_nowait and not self.conf.build_tasks:
             if builder.creates_tasks():

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -558,6 +558,10 @@ class Application(object):
                     build_dict.pop(opt)
                 results_store.set_build_data(version, build_dict)
 
+            except RebaseHelperError:
+                # Proper RebaseHelperError instance was created already. Re-raise it.
+                raise
+
             except SourcePackageBuildError as e:
                 build_dict.update(builder.get_logs())
                 build_dict['source_package_build_error'] = six.text_type(e)

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -901,9 +901,8 @@ class KojiHelper(object):
             return koji_session
         try:
             koji_session.krb_login()
-        except koji.krbV.Krb5Error:
-            # fall back to login using certificate
-            koji_session.ssl_login(cls.cert, cls.ca_cert, cls.ca_cert)
+        except koji.krbV.Krb5Error as e:
+            raise RebaseHelperError('Kerberos login failed. The error reported is: %s' % (six.text_type(e)))
         return koji_session
 
     @classmethod


### PR DESCRIPTION
Base Exceptions are very non-informative when building packages. We should consider logging the errors into debug log.

Fixes: #376 