### PR TITLE
Fix failing test on F26 due to missing make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN dnf -y install \
   dnf-plugins-core \
   # needed by rpm-py-installer.
   rpm-devel \
+  # necessary for tests that are using rpmbuild. (missing make etc.)
+  @buildsys-build \
   && dnf clean all
 
 CMD ["/usr/bin/tox"]


### PR DESCRIPTION
Add `@development-tools` to Dockerfile dependencies as `make` is part of it.

`make` is not installed as a dependency of the other packages, while being needed by packages that are tested in https://github.com/rebase-helper/rebase-helper/commit/176daef0fa215850af27dbce173912a3ae643585#diff-6d588bc259cac6db1bdba0eac89f42d5R35