### PR TITLE
Generate sample config file

### DIFF
--- a/rebasehelper/sample_config.py
+++ b/rebasehelper/sample_config.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import os
+import sys
+
+from argparse import SUPPRESS
+
+from rebasehelper.cli import CLI
+from rebasehelper.constants import CONFIG_PATH, CONFIG_FILENAME
+
+
+class SampleConfig(object):
+
+    DESCRIPTION = [
+        '# sample configuration file for rebase-helper',
+        '# copy this file to {} and edit it as necessary'.format(os.path.join(CONFIG_PATH, CONFIG_FILENAME)),
+        '# all options specified here can be overridden on the command line',
+    ]
+
+    BLACKLIST = [
+        'help',
+        'version',
+        'config-file',
+    ]
+
+    @classmethod
+    def generate(cls):
+        result = cls.DESCRIPTION + ['']
+        parser = CLI.build_parser()
+        result.append('[general]')
+        for action in parser._get_optional_actions():
+            if action.help is SUPPRESS:
+                continue
+            fmt = parser._get_formatter()
+            opts = action.option_strings
+            if len(opts) > 1:
+                opts.pop(0)
+            name = opts[0].lstrip('-')
+            if name in cls.BLACKLIST:
+                continue
+            value = getattr(action, 'actual_default', None)
+            if isinstance(value, list):
+                value = ','.join(value)
+            args = fmt._format_args(action, action.dest.upper())
+            result.append('')
+            result.append('# {}'.format(fmt._expand_help(action)))
+            if args:
+                result.append('# synopsis: {} = {}'.format(name, args))
+            result.append('{} = {}'.format(name, value if value is not None else ''))
+        return '\n'.join(result)
+
+
+def main():
+    if len(sys.argv) != 2:
+        return 1
+    s = SampleConfig.generate()
+    with open(sys.argv[1], 'w') as f:
+        f.write(s)
+    return 0
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Resolves: #369.

Generated config file currently looks like this:

```ini
# sample configuration file for rebase-helper
# copy this file to $XDG_CONFIG_HOME/rebase-helper.cfg and edit it as necessary
# all options specified here can be overridden on the command line

[general]

# be more verbose
verbose = False

# colorize the output, defaults to auto
# synopsis: color = {always,never,auto}
color = auto

# directory where rebase-helper output will be stored
# synopsis: results-dir = RESULTS_DIR
results-dir = 

# only apply patches
patch-only = False

# only build SRPMs and RPMs
build-only = False

# compare already built packages, COMPAREPKGS_DIR must be a directory with the following structure: <dir_name>/{old,new}/RPM
# synopsis: comparepkgs-only = COMPAREPKGS_DIR
comparepkgs-only = False

# continue previously interrupted rebase
continue = False

# build tool to use, defaults to mock
# synopsis: buildtool = {copr,rpmbuild,koji,mock}
buildtool = mock

# SRPM build tool to use, defaults to rpmbuild
# synopsis: srpm-buildtool = {rpmbuild,mock}
srpm-buildtool = rpmbuild

# set of tools to use for package comparison, defaults to rpmdiff,abipkgdiff,pkgdiff
# synopsis: pkgcomparetool = {rpmdiff,abipkgdiff,pkgdiff,csmock}
pkgcomparetool = rpmdiff,abipkgdiff,pkgdiff

# tool to use for formatting rebase output, defaults to text
# synopsis: outputtool = {text,json}
outputtool = text

# tool to use for determining latest upstream version
# synopsis: versioneer = {cpan,pypi,rubygems,anitya,npmjs}
versioneer = 

# do not interact with user
non-interactive = False

# do not download sources
not-download-sources = False

# do not remove workspace directory after finishing
keep-workspace = False

# disable inapplicable patches in rebased SPEC file
disable-inapplicable-patches = False

# do not build old sources, download latest build from Koji instead
get-old-build-from-koji = False

# force rebase even if current version is newer than requested version
skip-version-check = False

# do not wait for remote builds to finish
builds-nowait = False

# comma-separated remote build task ids
# synopsis: build-tasks = OLD_TASK,NEW_TASK
build-tasks = 

# enable arbitrary local builder option(s), enclose BUILDER_OPTIONS in quotes to pass more than one
# synopsis: builder-options = BUILDER_OPTIONS
builder-options = 

# enable arbitrary local srpm builder option(s), enclose SRPM_BUILDER_OPTIONS in quotes to pass more than one
# synopsis: srpm-builder-options = SRPM_BUILDER_OPTIONS
srpm-builder-options = 

# text to use as changelog entry, can contain RPM macros, which will be expanded
# synopsis: changelog-entry = CHANGELOG_ENTRY
changelog-entry = - New upstream release %{version}
```

@skisela, @FrNecas: Any thoughts? What else to blacklist for instance...