### PR TITLE
Multiple fixes

### DIFF
--- a/rebasehelper/archive.py
+++ b/rebasehelper/archive.py
@@ -26,6 +26,9 @@ import zipfile
 import bz2
 import os
 import shutil
+
+import six
+
 try:
     import lzma
 except ImportError:
@@ -236,7 +239,16 @@ class Archive(object):
 
         logger.debug("Extracting '%s' into '%s'", self._filename, path)
 
-        archive = self._archive_type.open(self._filename)
+        try:
+            LZMAError = lzma.LZMAError
+        except AttributeError:
+            LZMAError = lzma.error
+
+        try:
+            archive = self._archive_type.open(self._filename)
+        except (tarfile.ReadError, LZMAError) as e:
+            raise IOError(six.text_type(e))
+
         self._archive_type.extract(archive, self._filename, path)
         try:
             archive.close()

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -1024,7 +1024,7 @@ class SpecFile(object):
         """
         # rpm-python does not provide any directive for getting %files section
         # Therefore we should do that workaround
-        section_headers_re = [re.compile('^{0}.*'.format(x)) for x in self.defined_sections]
+        section_headers_re = [re.compile('^{0}.*'.format(x), re.IGNORECASE) for x in self.defined_sections]
 
         section_starts = []
         # First of all we need to find beginning of all sections
@@ -1060,7 +1060,7 @@ class SpecFile(object):
         :return: list of lines contained in the selected section
         """
         for sec_name, section in six.itervalues(self.rpm_sections):
-            if sec_name == section_name:
+            if sec_name.lower() == section_name.lower():
                 return section
 
     def set_spec_section(self, section_name, new_section):
@@ -1071,7 +1071,7 @@ class SpecFile(object):
         :return: list of lines contained in the selected section
         """
         for key, val in six.iteritems(self.rpm_sections):
-            if section_name in val[0]:
+            if section_name.lower() in val[0].lower():
                 if isinstance(new_section, str):
                     self.rpm_sections[key] = (section_name, new_section.split('\n'))
                 else:

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -957,10 +957,11 @@ class SpecFile(object):
 
         logger.debug("Extracting version from '%s' using '%s'", name, url_base)
         # expect that the version macro can be followed by another macros
-        regex_str = re.sub(r'%{version}(%{.+})?', version_regex_str, url_base, flags=re.IGNORECASE)
+        regex_str = re.sub(r'%{version}(%{.+})?', 'PLACEHOLDER', url_base, flags=re.IGNORECASE)
+        regex_str = re.escape(regex_str).replace('PLACEHOLDER', version_regex_str)
 
         # if no substitution was made, use the fallback regex
-        if regex_str == url_base:
+        if regex_str == re.escape(url_base):
             logger.debug('Using fallback regex to extract version from archive name.')
             regex_str = fallback_regex_str
         else:

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -261,7 +261,7 @@ class SpecFile(object):
         :param source_num: number of the source of which to get the raw string
         :return: string of the source or None if there is no such source
         """
-        source_re_str = '^Source0?:[ \t]*(.*?)$' if source_num == 0 else '^Source{0}:[ \t]*(.*?)$'.format(source_num)
+        source_re_str = '^Source0?\s*:\s*(.*?)$' if source_num == 0 else '^Source{0}\s*:\s*(.*?)$'.format(source_num)
         source_re = re.compile(source_re_str)
 
         for line in self.spec_content:
@@ -556,7 +556,7 @@ class SpecFile(object):
         :param macro:
         :return:
         """
-        search_re = re.compile(r'^Release:\s*[0-9.]*[0-9]+\.{0}%{{\?dist}}\s*'.format(macro))
+        search_re = re.compile(r'^Release\s*:\s*[0-9.]*[0-9]+\.{0}%{{\?dist}}\s*'.format(macro))
 
         for index, line in enumerate(self.spec_content):
             match = search_re.search(line)
@@ -616,7 +616,7 @@ class SpecFile(object):
                 self.redefine_release_with_macro(extra_version_macro)
 
                 # change the Source0 definition
-                source0_re = re.compile(r'^Source0?:.+')
+                source0_re = re.compile(r'^Source0?\s*:.+')
                 for index, line in enumerate(self.spec_content):
                     if source0_re.search(line):
                         # comment out the original Source0 line
@@ -889,7 +889,7 @@ class SpecFile(object):
                 return curval
             return result
 
-        tag_re = re.compile(r'^(?P<name>\w+):\s*(?P<value>.+)$')
+        tag_re = re.compile(r'^(?P<name>\w+)\s*:\s*(?P<value>.+)$')
         for index, line in enumerate(self.spec_content):
             match = tag_re.match(line)
             if not match:

--- a/rebasehelper/tests/test_archive.py
+++ b/rebasehelper/tests/test_archive.py
@@ -34,6 +34,8 @@ class TestArchive(object):
     TAR_BZ2 = 'archive.tar.bz2'
     ZIP = 'archive.zip'
     BZ2 = 'file.txt.bz2'
+    INVALID_TAR_BZ2 = 'archive-invalid.tar.bz2'
+    INVALID_TAR_XZ = 'archive-invalid.tar.xz'
 
     ARCHIVED_FILE = 'file.txt'
     ARCHIVED_FILE_CONTENT = 'simple testing file'
@@ -45,7 +47,9 @@ class TestArchive(object):
         TAR_XZ,
         TAR_BZ2,
         BZ2,
-        ZIP
+        ZIP,
+        INVALID_TAR_BZ2,
+        INVALID_TAR_XZ,
     ]
 
     @pytest.fixture
@@ -79,3 +83,16 @@ class TestArchive(object):
         #  check the content
         with open(extracted_file) as f:
             assert f.read().strip() == self.ARCHIVED_FILE_CONTENT
+
+    @pytest.mark.parametrize('archive', [
+        INVALID_TAR_BZ2,
+        INVALID_TAR_XZ,
+    ], ids=[
+        'tar.bz2',
+        'tar.xz',
+    ])
+    def test_invalid_archive(self, archive, workdir):
+        a = Archive(archive)
+        d = os.path.join(workdir, 'dir')
+        with pytest.raises(IOError):
+            a.extract_archive(d)

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -213,6 +213,9 @@ class TestSpecFile(object):
         name = 'http://downloads.sourceforge.net/%{name}/%{name}-%{version}%{?prever:_%{prever}}.tar.xz'
         assert SpecFile.extract_version_from_archive_name('log4cplus-1.1.3_rc3.tar.xz',
                                                           name) == ('1.1.3', 'rc3', '_')
+        name = 'http://download.gnome.org/sources/libsigc++/%{release_version}/libsigc++-%{version}.tar.xz'
+        assert SpecFile.extract_version_from_archive_name('libsigc++-2.10.0.tar.xz',
+                                                          name) == ('2.10.0', '', '')
 
     def test__split_sections(self, spec_object):
         expected_sections = {
@@ -240,7 +243,7 @@ class TestSpecFile(object):
                             '# so look there if you fail to retrieve the version you want\n',
                             'Source: ftp://ftp.test.org/%{name}-%{version}.tar.xz\n',
                             'Source1: source-tests.sh\n',
-                            'Source2: ftp://test.com/test-source.sh\n',
+                            'Source2 : ftp://test.com/test-source.sh\n',
                             '#Source3: source-tests.sh\n',
                             'Source4: file.txt.bz2\n',
                             'Source5: documentation.tar.xz\n',
@@ -297,13 +300,17 @@ class TestSpecFile(object):
         }
         sections = spec_object._split_sections()
         for key, value in six.iteritems(expected_sections):
-            assert sections[key][0] == value[0]
+            assert sections[key][0].lower() == value[0].lower()
             assert sections[key][1] == value[1]
 
     def test_get_spec_section(self, spec_object):
         expected_section = ['%{_bindir}/file.txt\n',
                             '\n']
         section = spec_object.get_spec_section('%files')
+        assert section == expected_section
+        expected_section = ['make DESTDIR=$RPM_BUILD_ROOT install\n',
+                            '\n']
+        section = spec_object.get_spec_section('%install')
         assert section == expected_section
 
     def test_spec_missing_file(self, spec_object):

--- a/rebasehelper/tests/testing_files/archive-invalid.tar.bz2
+++ b/rebasehelper/tests/testing_files/archive-invalid.tar.bz2
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Page Not Found</title>
+</head>
+<body>
+    <h1>Page Not Found</h1>
+    <p>Sorry, but the page you were trying to view does not exist.</p>
+</body>
+</html>

--- a/rebasehelper/tests/testing_files/archive-invalid.tar.xz
+++ b/rebasehelper/tests/testing_files/archive-invalid.tar.xz
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Page Not Found</title>
+</head>
+<body>
+    <h1>Page Not Found</h1>
+    <p>Sorry, but the page you were trying to view does not exist.</p>
+</body>
+</html>

--- a/rebasehelper/tests/testing_files/test.spec
+++ b/rebasehelper/tests/testing_files/test.spec
@@ -22,7 +22,7 @@ URL: http://testing.org
 # so look there if you fail to retrieve the version you want
 Source: ftp://ftp.test.org/%{name}-%{version}.tar.xz
 Source1: source-tests.sh
-Source2: ftp://test.com/test-source.sh
+Source2 : ftp://test.com/test-source.sh
 #Source3: source-tests.sh
 Source4: file.txt.bz2
 Source5: documentation.tar.xz
@@ -60,7 +60,7 @@ autoreconf -vi
 %configure
 make TEST
 
-%install
+%Install
 make DESTDIR=$RPM_BUILD_ROOT install
 
 %check


### PR DESCRIPTION
* Handle exceptions while opening archive
  - resolves #383
* Handle whitespace before colon in tag definitions
  - resolves #387
* Escape source string before constructing regexp from it
  - resolves #388
* Handle mixed-case spec sections
  - resolves #389