### PR TITLE
Stop updating docker on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ env:
     - DOCKER_IMAGE=fedora:26
     - DOCKER_IMAGE=fedora:latest
     - DOCKER_IMAGE=fedora:rawhide
-before_install:
-    # Update docker to allow using ARG in FROM (>= 17.05.0-ce)
-    # https://github.com/moby/moby/blob/master/CHANGELOG.md
-    - sudo apt-get update
-    - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 install: true
 before_script:
     - |


### PR DESCRIPTION
It is no longer necessary as installed docker version is now `17.09.0-ce`.