### PR TITLE
Fix progress bar for downloading from http

### DIFF
--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -297,7 +297,7 @@ class DownloadHelper(object):
         :return: None
         """
         session = requests_ftp.ftp.FTPSession()
-        r = session.get(url)
+        r = session.get(url, stream=True)
         if not 200 <= r.status_code < 300:
             raise DownloadError(r.reason)
 


### PR DESCRIPTION
_stream=True_ was missing, so the file was not downloaded continuously and progress bar immediately jumped to 100%.

Resolves: #411 