### PR TITLE
Get error from koji and process it

### DIFF
--- a/rebasehelper/build_helper.py
+++ b/rebasehelper/build_helper.py
@@ -57,6 +57,8 @@ class BinaryPackageBuildError(RuntimeError):
         :param kwargs: dictionary containing path to the logfile that contains main errors
         """
         self.args = args
+        # Return code obtained from koji only at this time
+        self.return_code = kwargs.get('return_code')
         self.logfile = kwargs.get('logfile')
 
 


### PR DESCRIPTION
As mentioned in https://pagure.io/koji/issue/712 getTaskResult raises exception which contains koji error message, in case the build failed.