### PR TITLE
Use custom requests adapter instead of requests_ftp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ def get_requirements():
         'copr',
         'pyquery',
         'requests',
-        'requests_ftp',
         'six',
         'GitPython',
         'ansicolors',


### PR DESCRIPTION
Download progress is not indicated properly with FTP transfers because stream mode is not supported in `requests_ftp`.

Implement custom urllib-based `FTPAdapter` instead.
 
Resolves #413.