### PR TITLE
Move pylint exclusions from pylintrc to tox.ini

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -59,20 +59,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=
-    C,R,W,
-    # E
-    print-statement,
-    parameter-unpacking,
-    unpacking-in-except,
-    old-raise-syntax,
-    backtick,
-    long-suffix,
-    old-ne-operator,
-    old-octal-literal,
-    # I
-    suppressed-message,
-    useless-suppression
+#disable=
 
 
 [REPORTS]

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,19 @@ basepython=python3
 [lint]
 skip_install=true
 commands=
-    pylint --rcfile=pylintrc rebasehelper
+    pylint --rcfile=pylintrc \
+           --disable=C,R,W \
+           --disable=print-statement \
+           --disable=parameter-unpacking \
+           --disable=unpacking-in-except \
+           --disable=old-raise-syntax \
+           --disable=backtick \
+           --disable=long-suffix \
+           --disable=old-ne-operator \
+           --disable=old-octal-literal \
+           --disable=suppressed-message \
+           --disable=useless-suppression \
+           rebasehelper
 deps=
     -rlint-requirements.txt
 


### PR DESCRIPTION
Landscape.io does checks based on pylintrc, and we want to see all the problems.