### PR TITLE
Add CommitHashUpdater SPEC hook

### DIFF
--- a/rebasehelper/spec_hooks/commit_hash_updater.py
+++ b/rebasehelper/spec_hooks/commit_hash_updater.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# This tool helps you to rebase package to the latest version
+# Copyright (C) 2013-2014 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#          Tomas Hozza <thozza@redhat.com>
+
+import re
+
+import requests
+
+from rebasehelper.specfile import BaseSpecHook
+from rebasehelper.logger import logger
+
+
+class CommitHashUpdaterHook(BaseSpecHook):
+    """Tries to update commit hash present in Source0 tag according to the new version"""
+
+    NAME = 'Commit Hash Updater'
+    CATEGORIES = None
+
+    @classmethod
+    def get_name(cls):
+        return cls.NAME
+
+    @classmethod
+    def get_categories(cls):
+        return cls.CATEGORIES
+
+    @classmethod
+    def _get_commit_hash_from_github(cls, spec_file):
+        """
+        Tries to find a commit using Github API
+
+        :param spec_file: SPEC file to base the search on
+        :return: SHA of a commit, or None
+        """
+        m = re.match(r'^https?://github\.com/(?P<owner>[\w-]+)/(?P<project>[\w-]+)/.*$', spec_file.sources[0])
+        if not m:
+            return None
+        baseurl = 'https://api.github.com/repos/{owner}/{project}'.format(**m.groupdict())
+        # try to get tag name from a release matching version
+        r = requests.get('{}/releases'.format(baseurl))
+        if not r.ok:
+            if r.status_code == 403 and r.headers.get('X-RateLimit-Remaining') == '0':
+                logger.warning("Rate limit exceeded on Github API! Try again later.")
+            return None
+        data = r.json()
+        version = spec_file.get_version()
+        tag_name = None
+        for release in data:
+            if version in release.get('name'):
+                tag_name = release.get('tag_name')
+                break
+        r = requests.get('{}/tags'.format(baseurl))
+        if not r.ok:
+            if r.status_code == 403 and r.headers.get('X-RateLimit-Remaining') == '0':
+                logger.warning("Rate limit exceeded on Github API! Try again later.")
+            return None
+        data = r.json()
+        for tag in data:
+            name = tag.get('name')
+            if tag_name:
+                if name != tag_name:
+                    continue
+            else:
+                # no specific tag name, try common tag names
+                if name not in [version, 'v{}'.format(version)]:
+                    continue
+            commit = tag.get('commit')
+            if commit:
+                return commit.get('sha')
+        return None
+
+    @classmethod
+    def _get_commit_hash(cls, spec_file):
+        if 'github.com' in spec_file.sources[0]:
+            return cls._get_commit_hash_from_github(spec_file)
+        return None
+
+    @classmethod
+    def run(cls, spec_file, rebase_spec_file, **kwargs):
+        if rebase_spec_file.sources[0] != spec_file.sources[0]:
+            # nothing to do
+            return
+        # try to determine commit hash matching the new version
+        new_commit = cls._get_commit_hash(rebase_spec_file)
+        if not new_commit:
+            return
+        source = rebase_spec_file.sources[0]
+        # try to determine commit hash matching the old version
+        old_commit = cls._get_commit_hash(spec_file)
+        if old_commit:
+            # replace old commit hash with the new one
+            source = source.replace(old_commit, new_commit)
+        else:
+            # try to find anything resembling SHA1 hash
+            hashes = re.findall(r'[0-9a-f]{40}', source)
+            if len(set(hashes)) != 1:
+                # multiple different hashes (or none), cannot continue
+                return
+            source = source.replace(hashes[0], new_commit)
+        tag = 'Source0'
+        if [l for l in rebase_spec_file.spec_content if re.match(r'^Source\s*:.*', l)]:
+            tag = 'Source'
+        rebase_spec_file.set_tag(tag, source, preserve_macros=True)

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -239,6 +239,9 @@ class TestSpecFile(object):
                             '%global release 34\n',
                             '%global release_str %{release}%{?dist}\n',
                             '\n',
+                            '%global project rebase-helper\n',
+                            '%global commit d70cb5a2f523db5b6088427563531f43b7703859\n',
+                            '\n',
                             'Summary: %{summary}\n',
                             'Name: test\n',
                             'Version: %{version}\n',
@@ -257,6 +260,8 @@ class TestSpecFile(object):
                             'Source5: documentation.tar.xz\n',
                             'Source6: misc.zip\n',
                             'Source7: https://pypi.python.org/packages/source/p/positional/positional-1.1.0.tar.gz\n',
+                            'Source8: https://github.com/%{project}/%{project}/archive/%{commit}/'
+                            '%{project}-%{commit}.tar.gz\n',
                             'Patch1: test-testing.patch\n',
                             'Patch2: test-testing2.patch\n',
                             'Patch3: test-testing3.patch\n',
@@ -532,10 +537,29 @@ class TestSpecFile(object):
                 'Release: %{release_str}\n',
             ],
         ),
+        (
+            'Source8',
+            'https://github.com/rebase-helper/rebase-helper/archive/'
+            'b0ed0b235bd5ea295fc897e1e2e8e6b6637f2c2d/'
+            'rebase-helper-b0ed0b235bd5ea295fc897e1e2e8e6b6637f2c2d.tar.gz',
+            [
+                '%global project rebase-helper\n',
+                '%global commit d70cb5a2f523db5b6088427563531f43b7703859\n',
+                'Source8: https://github.com/rebase-helper/rebase-helper/archive/'
+                'b0ed0b235bd5ea295fc897e1e2e8e6b6637f2c2d/'
+                'rebase-helper-b0ed0b235bd5ea295fc897e1e2e8e6b6637f2c2d.tar.gz\n',
+            ],
+            [
+                '%global project rebase-helper\n',
+                '%global commit b0ed0b235bd5ea295fc897e1e2e8e6b6637f2c2d\n',
+                'Source8: https://github.com/%{project}/%{project}/archive/%{commit}/%{project}-%{commit}.tar.gz\n',
+            ],
+        ),
     ], ids=[
         'Summary=>"A testing SPEC file..."',
         'Version=>"1.1.8"',
         'Release=>"42%{?dist}"',
+        'Source8=>"https://github.com/rebase-helper/rebase-helper/archive/..."',
     ])
     def test_set_tag(self, spec_object, preserve_macros, tag, value, lines, lines_preserve):
         spec_object.set_tag(tag, value, preserve_macros=preserve_macros)

--- a/rebasehelper/tests/testing_files/test.spec
+++ b/rebasehelper/tests/testing_files/test.spec
@@ -10,6 +10,9 @@
 %global release 34
 %global release_str %{release}%{?dist}
 
+%global project rebase-helper
+%global commit d70cb5a2f523db5b6088427563531f43b7703859
+
 Summary: %{summary}
 Name: test
 Version: %{version}
@@ -28,6 +31,7 @@ Source4: file.txt.bz2
 Source5: documentation.tar.xz
 Source6: misc.zip
 Source7: https://pypi.python.org/packages/source/p/positional/positional-1.1.0.tar.gz
+Source8: https://github.com/%{project}/%{project}/archive/%{commit}/%{project}-%{commit}.tar.gz
 Patch1: test-testing.patch
 Patch2: test-testing2.patch
 Patch3: test-testing3.patch

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
             'typo_fix = rebasehelper.spec_hooks.typo_fix:TypoFixHook',
             'pypi_url_fix = rebasehelper.spec_hooks.pypi_url_fix:PyPIURLFixHook',
             'ruby_helper = rebasehelper.spec_hooks.ruby_helper:RubyHelperHook',
+            'commit_hash_updater = rebasehelper.spec_hooks.commit_hash_updater:CommitHashUpdaterHook',
         ],
         'rebasehelper.versioneers': [
             'anitya = rebasehelper.versioneers.anitya_versioneer:AnityaVersioneer',


### PR DESCRIPTION
`CommitHashUpdaterHook` tries to update commit hash present in `Source0` tag according to the new version.

Only `github.com` is supported so far via [Github API](https://developer.github.com/v3/). But it seems majority of packages using commit hashes are Github based.

Resolves: #372