### PR TITLE
Refactor build process

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -60,7 +60,6 @@ class Application(object):
     debug_log_file = None
     report_log_file = None
     rebased_patches = {}
-    upstream_monitoring = False
     rebased_repo = None
 
     def __init__(self, cli_conf, execution_dir, results_dir, debug_log_file):
@@ -749,37 +748,12 @@ class Application(object):
         for version in ['old', 'new']:
             logger.info(builder.get_task_info(logs[version]))
 
-    def set_upstream_monitoring(self):
-        # This function is used by the-new-hotness, do not remove it!
-        self.upstream_monitoring = True
-
     def get_rebasehelper_data(self):
         rh_stuff = {}
         rh_stuff['build_logs'] = self.get_new_build_logs()
         rh_stuff['patches'] = self.get_rebased_patches()
         rh_stuff['checkers'] = self.get_checker_outputs()
         rh_stuff['logs'] = self.get_all_log_files()
-        return rh_stuff
-
-    def run_download_compare(self, tasks_dict, dir_name):
-        # TODO: Add doc text with explanation
-        self.set_upstream_monitoring()
-        kh = KojiHelper()
-        for version in ['old', 'new']:
-            rh_dict = {}
-            compare_dirname = os.path.join(dir_name, version)
-            if not os.path.exists(compare_dirname):
-                os.mkdir(compare_dirname, 0o777)
-            (task, upstream_version, package) = tasks_dict[version]
-            rh_dict['rpm'], rh_dict['logs'] = kh.get_koji_tasks([task], compare_dirname)
-            rh_dict['version'] = upstream_version
-            rh_dict['name'] = package
-            results_store.set_build_data(version, rh_dict)
-        if tasks_dict['status'] == 'CLOSED':
-            self.run_package_checkers(dir_name)
-        self.print_summary()
-        rh_stuff = self.get_rebasehelper_data()
-        logger.info(rh_stuff)
         return rh_stuff
 
     def run(self):

--- a/rebasehelper/build_helper.py
+++ b/rebasehelper/build_helper.py
@@ -155,6 +155,21 @@ class RpmbuildTemporaryEnvironment(BuildTemporaryEnvironment):
             os.makedirs(self._env[self.TEMPDIR + '_' + dir_name])
 
 
+class MockTemporaryEnvironment(BuildTemporaryEnvironment):
+    """
+    Class representing temporary environment for MockBuildTool.
+    """
+
+    def _create_directory_structure(self):
+        # create directory structure
+        for dir_name in ['SOURCES', 'SPECS', 'RESULTS']:
+            self._env[self.TEMPDIR + '_' + dir_name] = os.path.join(
+                self._env[self.TEMPDIR], dir_name)
+            logger.debug("Creating '%s'",
+                         self._env[self.TEMPDIR + '_' + dir_name])
+            os.makedirs(self._env[self.TEMPDIR + '_' + dir_name])
+
+
 class BuildToolBase(object):
     """
     Base class for various build tools

--- a/rebasehelper/build_helper.py
+++ b/rebasehelper/build_helper.py
@@ -213,7 +213,7 @@ class BuildToolBase(object):
         pass
 
     @classmethod
-    def build(cls, spec, sources, patches, results_dir, **kwargs):
+    def build(cls, spec, results_dir, srpm, **kwargs):
         """
         Build binaries from the sources.
 
@@ -239,7 +239,7 @@ class BuildToolBase(object):
         dict with
         'logs' -> list of absolute paths to logs
         """
-        raise NotImplementedError()
+        return dict(logs=getattr(cls, 'logs', None))
 
     @classmethod
     def wait_for_task(cls, build_dict, results_dir):  # pylint: disable=unused-argument
@@ -441,7 +441,7 @@ class Builder(object):
 
     def build(self, *args, **kwargs):
         """Build sources."""
-        logger.debug("Building sources using '%s'", self._tool_name)
+        logger.debug("Building RPMs using '%s'", self._tool_name)
         return self._tool.build(*args, **kwargs)
 
     def get_logs(self):

--- a/rebasehelper/build_tools/copr_tool.py
+++ b/rebasehelper/build_tools/copr_tool.py
@@ -92,23 +92,18 @@ class CoprBuildTool(BuildToolBase):
         return rpms, logs, build_id
 
     @classmethod
-    def build(cls, spec, sources, patches, results_dir, **kwargs):
+    def build(cls, spec, results_dir, srpm, **kwargs):
         """
-        Builds the SRPM using rpmbuild
         Builds the RPMs using copr
 
-        :param spec: absolute path to the SPEC file.
-        :param sources: list with absolute paths to SOURCES
-        :param patches: list with absolute paths to PATCHES
+        :param spec: SpecFile object
         :param results_dir: absolute path to DIR where results should be stored
+        :param srpm: absolute path to SRPM
         :return: dict with:
-                 'srpm' -> absolute path to SRPM
                  'rpm' -> list with absolute paths to RPMs
                  'logs' -> list with absolute paths to build_logs
+                 'copr_build_id' -> ID of copr build
         """
-        # build SRPM
-        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir, **kwargs)
-        # build RPMs
         rpm_results_dir = os.path.join(results_dir, "RPM")
         os.makedirs(rpm_results_dir)
         if not cls.copr_helper:
@@ -116,14 +111,7 @@ class CoprBuildTool(BuildToolBase):
         rpms, rpm_logs, build_id = cls._build_rpms(srpm, **kwargs)
         if rpm_logs:
             cls.logs.extend(rpm_logs)
-        return {'srpm': srpm,
-                'rpm': rpms,
-                'logs': cls.logs,
-                'copr_build_id': build_id}
-
-    @classmethod
-    def get_logs(cls):
-        return {'logs': cls.logs}
+        return dict(rpm=rpms, logs=cls.logs, copr_build_id=build_id)
 
     @classmethod
     def get_task_info(cls, build_dict):

--- a/rebasehelper/build_tools/koji_tool.py
+++ b/rebasehelper/build_tools/koji_tool.py
@@ -130,10 +130,6 @@ class KojiBuildTool(BuildToolBase):
             return int(match.group(1))
 
     @classmethod
-    def get_logs(cls):
-        return {'logs': cls.logs}
-
-    @classmethod
     def wait_for_task(cls, build_dict, results_dir):
         if not cls.koji_helper:
             cls.koji_helper = KojiHelper()
@@ -161,24 +157,19 @@ class KojiBuildTool(BuildToolBase):
             return None, None
 
     @classmethod
-    def build(cls, spec, sources, patches, results_dir, **kwargs):
+    def build(cls, spec, results_dir, srpm, **kwargs):
         """
-        Builds the SRPM using rpmbuild
         Builds the RPMs using koji
 
-        :param spec: absolute path to the SPEC file.
-        :param sources: list with absolute paths to SOURCES
-        :param patches: list with absolute paths to PATCHES
+        :param spec: SpecFile object
         :param results_dir: absolute path to DIR where results should be stored
+        :param srpm: absolute path to SRPM
         :param upstream_monitoring: specify if build is handled by upstream monitoring
         :return: dict with:
-                 'srpm' -> absolute path to SRPM
                  'rpm' -> list with absolute paths to RPMs
                  'logs' -> list with absolute paths to build_logs
+                 'koji_task_id' -> ID of koji task
         """
-        # build SRPM
-        srpm, cls.logs = cls._build_srpm(spec, sources, patches, results_dir, **kwargs)
-        # build RPMs
         rpm_results_dir = os.path.join(results_dir, "RPM")
         os.makedirs(rpm_results_dir)
         if not cls.koji_helper:
@@ -186,7 +177,4 @@ class KojiBuildTool(BuildToolBase):
         rpms, rpm_logs, koji_task_id = cls._scratch_build(srpm, **kwargs)
         if rpm_logs:
             cls.logs.extend(rpm_logs)
-        return {'srpm': srpm,
-                'rpm': rpms,
-                'logs': cls.logs,
-                'koji_task_id': koji_task_id}
+        return dict(rpm=rpms, logs=cls.logs, koji_task_id=koji_task_id)

--- a/rebasehelper/build_tools/mock_tool.py
+++ b/rebasehelper/build_tools/mock_tool.py
@@ -25,24 +25,9 @@ import os
 from rebasehelper.utils import ProcessHelper
 from rebasehelper.logger import logger
 from rebasehelper.utils import PathHelper
-from rebasehelper.build_helper import BuildTemporaryEnvironment
 from rebasehelper.build_helper import BuildToolBase
 from rebasehelper.build_helper import BinaryPackageBuildError
-
-
-class MockTemporaryEnvironment(BuildTemporaryEnvironment):
-    """
-    Class representing temporary environment for MockBuildTool.
-    """
-
-    def _create_directory_structure(self):
-        # create directory structure
-        for dir_name in ['SOURCES', 'SPECS', 'RESULTS']:
-            self._env[self.TEMPDIR + '_' + dir_name] = os.path.join(
-                self._env[self.TEMPDIR], dir_name)
-            logger.debug("Creating '%s'",
-                         self._env[self.TEMPDIR + '_' + dir_name])
-            os.makedirs(self._env[self.TEMPDIR + '_' + dir_name])
+from rebasehelper.build_helper import MockTemporaryEnvironment
 
 
 class MockBuildTool(BuildToolBase):  # pylint: disable=abstract-method

--- a/rebasehelper/srpm_build_tools/rpmbuild_tool.py
+++ b/rebasehelper/srpm_build_tools/rpmbuild_tool.py
@@ -23,7 +23,7 @@
 import os
 
 from rebasehelper.logger import logger
-from rebasehelper.build_helper import SRPMBuildToolBase, SourcePackageBuildError
+from rebasehelper.build_helper import SRPMBuildToolBase, SourcePackageBuildError, RpmbuildTemporaryEnvironment
 from rebasehelper.utils import PathHelper
 from rebasehelper.utils import ProcessHelper
 
@@ -43,7 +43,7 @@ class RpmbuildSRPMBuildTool(SRPMBuildToolBase):
         return cls.DEFAULT
 
     @classmethod
-    def build_srpm(cls, spec, workdir, results_dir, srpm_results_dir, srpm_builder_options):
+    def _build_srpm(cls, spec, workdir, results_dir, srpm_results_dir, srpm_builder_options):
         """
         Build SRPM using rpmbuild.
 
@@ -77,3 +77,39 @@ class RpmbuildSRPMBuildTool(SRPMBuildToolBase):
         logfile = build_log_path
         cls.logs = [l for l in PathHelper.find_all_files(srpm_results_dir, '*.log')]
         raise SourcePackageBuildError("Building SRPM failed!", logfile=logfile)
+
+    @classmethod
+    def build(cls, spec, results_dir, **kwargs):
+        """
+        Build SRPM with chosen SRPM Build Tool
+
+        :param spec: SpecFile object
+        :param results_dir: absolute path to DIR where results should be stored
+        :return: absolute path to SRPM, list with absolute paths to logs
+        """
+        srpm_results_dir = os.path.join(results_dir, "SRPM")
+        sources = spec.get_sources()
+        patches = [p.get_path() for p in spec.get_patches()]
+        with RpmbuildTemporaryEnvironment(sources, patches, spec.get_path(),
+                                          srpm_results_dir) as tmp_env:
+            srpm_builder_options = cls.get_srpm_builder_options(**kwargs)
+
+            env = tmp_env.env()
+            tmp_dir = tmp_env.path()
+            tmp_spec = env.get(RpmbuildTemporaryEnvironment.TEMPDIR_SPEC)
+            tmp_results_dir = env.get(
+                RpmbuildTemporaryEnvironment.TEMPDIR_RESULTS)
+
+            srpm = cls._build_srpm(tmp_spec, tmp_dir, tmp_results_dir, srpm_results_dir,
+                                   srpm_builder_options=srpm_builder_options)
+
+        logger.info("Building SRPM finished successfully")
+
+        # srpm path in results_dir
+        srpm = os.path.join(srpm_results_dir, os.path.basename(srpm))
+        logger.debug("Successfully built SRPM: '%s'", str(srpm))
+        # gather logs
+        logs = [l for l in PathHelper.find_all_files(srpm_results_dir, '*.log')]
+        logger.debug("logs: '%s'", str(logs))
+
+        return dict(srpm=srpm, logs=logs)


### PR DESCRIPTION
This PR splits build process into two phases, build of source packages (SRPM) and build of binary packages (RPM).

This is necessary for SRPM checkers to be able to run just after SRPMs are built.
Also now one doesn't have to wait until all old-version RPMs are built only to find out there is some trivial error in rebased SPEC file and new-version SRPM build fails because of that.