### PR TITLE
Several fixes

### DIFF
--- a/rebasehelper/archive.py
+++ b/rebasehelper/archive.py
@@ -169,6 +169,12 @@ class TgzArchiveType(TarGzArchiveType):
 
 
 @register_archive_type
+class TarArchiveType(TarGzArchiveType):
+    """ .tar archive type """
+    EXTENSION = ".tar"
+
+
+@register_archive_type
 class ZipArchiveType(ArchiveTypeBase):
     """ .zip archive type """
     EXTENSION = ".zip"

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -277,7 +277,7 @@ class TestSpecFile(object):
                                    '\n']],
             3: ['%description devel', ['Testing devel spec file\n',
                                        '\n']],
-            4: ['%prep', ['%setup -q -a 5\n',
+            4: ['%prep', ['%setup -q -c -a 5\n',
                           '%patch1\n',
                           '%patch2 -p1\n',
                           '%patch3 -p1 -b .testing3\n',

--- a/rebasehelper/tests/testing_files/test.spec
+++ b/rebasehelper/tests/testing_files/test.spec
@@ -50,7 +50,7 @@ Summary: A testing devel package
 Testing devel spec file
 
 %prep
-%setup -q -a 5
+%setup -q -c -a 5
 %patch1
 %patch2 -p1
 %patch3 -p1 -b .testing3

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -20,6 +20,7 @@
 # Authors: Petr Hracek <phracek@redhat.com>
 #          Tomas Hozza <thozza@redhat.com>
 
+import argparse
 import io
 import os
 import re
@@ -1365,3 +1366,14 @@ class LookasideCacheHelper(object):
             raise LookasideCacheError('Failed to read rpkg configuration')
         for source in cls._read_sources(basepath):
             cls._download_source(tool, url, package, source['filename'], source['hashtype'], source['hash'])
+
+
+class ParseError(Exception):
+
+    pass
+
+
+class SilentArgumentParser(argparse.ArgumentParser):
+
+    def error(self, message):
+        raise ParseError(message)


### PR DESCRIPTION
* Add uncompressed tar to supported archive types (fixes #455)
* Do not use default error handler of ArgumentParser
* Fix testing spec file