### PR TITLE
Enhance console logging

### DIFF
--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -173,18 +173,18 @@ class CliHelper(object):
             app = Application(config, execution_dir, results_dir, debug_log_file)
             app.run()
         except KeyboardInterrupt:
-            logger.info('\nInterrupted by user')
+            logger.info('Interrupted by user')
         except RebaseHelperError as e:
             if e.msg:
-                logger.error('\n%s', e.msg)
+                logger.error('%s', e.msg)
             else:
-                logger.error('\n%s', six.text_type(e))
+                logger.error('%s', six.text_type(e))
             sys.exit(1)
         except SystemExit as e:
             sys.exit(e.code)
         except BaseException:
             if debug_log_file:
-                logger.error('\nrebase-helper failed due to an unexpected error. Please report this problem'
+                logger.error('rebase-helper failed due to an unexpected error. Please report this problem'
                              '\nusing the following link: %s'
                              '\nand include the content of'
                              '\n\'%s\''
@@ -192,12 +192,12 @@ class CliHelper(object):
                              '\nThank you!',
                              NEW_ISSUE_LINK, debug_log_file)
             else:
-                logger.error('\nrebase-helper failed due to an unexpected error. Please report this problem'
+                logger.error('rebase-helper failed due to an unexpected error. Please report this problem'
                              '\nusing the following link: %s'
                              '\nand include the traceback following this message in the report.'
                              '\nThank you!',
                              NEW_ISSUE_LINK)
-            logger.trace('\n', exc_info=1)
+            logger.trace('', exc_info=1)
             sys.exit(1)
 
         sys.exit(0)

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -167,7 +167,7 @@ class CliHelper(object):
             config = Config(getattr(cli, 'config-file', None))
             config.merge(cli)
             for handler in [main_handler, output_tool_handler]:
-                handler.set_terminal_background()
+                handler.set_terminal_background(config.background)
 
             ConsoleHelper.use_colors = ConsoleHelper.should_use_colors(config)
             execution_dir, results_dir, debug_log_file = Application.setup(config)

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -197,7 +197,7 @@ class CliHelper(object):
                              '\nand include the traceback following this message in the report.'
                              '\nThank you!',
                              NEW_ISSUE_LINK)
-            logger.debug('\n', exc_info=1)
+            logger.trace('\n', exc_info=1)
             sys.exit(1)
 
         sys.exit(0)

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -30,7 +30,7 @@ from rebasehelper.options import OPTIONS, traverse_options
 from rebasehelper.constants import PROGRAM_DESCRIPTION, NEW_ISSUE_LINK
 from rebasehelper.version import VERSION
 from rebasehelper.application import Application
-from rebasehelper.logger import logger, handler
+from rebasehelper.logger import logger, main_handler, output_tool_handler
 from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.utils import ConsoleHelper
 from rebasehelper.config import Config
@@ -166,10 +166,13 @@ class CliHelper(object):
 
             config = Config(getattr(cli, 'config-file', None))
             config.merge(cli)
+            for handler in [main_handler, output_tool_handler]:
+                handler.set_terminal_background()
+
             ConsoleHelper.use_colors = ConsoleHelper.should_use_colors(config)
             execution_dir, results_dir, debug_log_file = Application.setup(config)
             if not config.verbose:
-                handler.setLevel(logging.INFO)
+                main_handler.setLevel(logging.INFO)
             app = Application(config, execution_dir, results_dir, debug_log_file)
             app.run()
         except KeyboardInterrupt:

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -30,7 +30,7 @@ from rebasehelper.options import OPTIONS, traverse_options
 from rebasehelper.constants import PROGRAM_DESCRIPTION, NEW_ISSUE_LINK
 from rebasehelper.version import VERSION
 from rebasehelper.application import Application
-from rebasehelper.logger import logger, LoggerHelper
+from rebasehelper.logger import logger, handler
 from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.utils import ConsoleHelper
 from rebasehelper.config import Config
@@ -159,7 +159,6 @@ class CliHelper(object):
         debug_log_file = None
         try:
             # be verbose until debug_log_file is created
-            handler = LoggerHelper.add_stream_handler(logger, logging.DEBUG)
             cli = CLI()
             if hasattr(cli, 'version'):
                 logger.info(VERSION)

--- a/rebasehelper/logger.py
+++ b/rebasehelper/logger.py
@@ -125,22 +125,41 @@ class LoggerHelper(object):
 
 
 class ColorizingStreamHandler(logging.StreamHandler):
-    level_map = {
-        logging.DEBUG: {'fg': 'brightblack', 'bg': 'default', 'style': None},
-        CustomLogger.TRACE: {'fg': 'red', 'bg': 'default', 'style': None},
-        logging.INFO: {'fg': 'default', 'bg': 'default', 'style': None},
-        CustomLogger.SUCCESS: {'fg': 'green', 'bg': 'default', 'style': None},
-        CustomLogger.HEADING: {'fg': 'yellow', 'bg': 'default', 'style': None},
-        CustomLogger.IMPORTANT: {'fg': 'red', 'bg': 'default', 'style': None},
-        logging.WARNING: {'fg': 'yellow', 'bg': 'default', 'style': None},
-        logging.ERROR: {'fg': 'red', 'bg': 'default', 'style': 'bold'},
-        logging.CRITICAL: {'fg': 'white', 'bg': 'red', 'style': 'bold'},
+    colors = {
+        'dark': {
+            logging.DEBUG: {'fg': 'brightblack', 'bg': 'default', 'style': None},
+            CustomLogger.TRACE: {'fg': 'red', 'bg': 'default', 'style': None},
+            logging.INFO: {'fg': 'default', 'bg': 'default', 'style': None},
+            CustomLogger.SUCCESS: {'fg': 'green', 'bg': 'default', 'style': None},
+            CustomLogger.HEADING: {'fg': 'yellow', 'bg': 'default', 'style': None},
+            CustomLogger.IMPORTANT: {'fg': 'red', 'bg': 'default', 'style': None},
+            logging.WARNING: {'fg': 'yellow', 'bg': 'default', 'style': None},
+            logging.ERROR: {'fg': 'red', 'bg': 'default', 'style': 'bold'},
+            logging.CRITICAL: {'fg': 'white', 'bg': 'red', 'style': 'bold'},
+        },
+        'light': {
+            logging.DEBUG: {'fg': 'brightblack', 'bg': 'default', 'style': None},
+            CustomLogger.TRACE: {'fg': 'red', 'bg': 'default', 'style': None},
+            logging.INFO: {'fg': 'default', 'bg': 'default', 'style': None},
+            CustomLogger.SUCCESS: {'fg': 'green', 'bg': 'default', 'style': None},
+            CustomLogger.HEADING: {'fg': 'blue', 'bg': 'default', 'style': None},
+            CustomLogger.IMPORTANT: {'fg': 'red', 'bg': 'default', 'style': None},
+            logging.WARNING: {'fg': 'blue', 'bg': 'default', 'style': None},
+            logging.ERROR: {'fg': 'red', 'bg': 'default', 'style': 'bold'},
+            logging.CRITICAL: {'fg': 'white', 'bg': 'red', 'style': 'bold'},
+        },
     }
+
+    terminal_background = 'dark'
+
+    def set_terminal_background(self):
+        self.terminal_background = rebasehelper.utils.ConsoleHelper.detect_background()
 
     def emit(self, record):
         try:
             message = self.format(record)
-            rebasehelper.utils.ConsoleHelper.cprint(message, **self.level_map.get(record.levelno, {}))
+            level_settings = self.colors[self.terminal_background].get(record.levelno, {})
+            rebasehelper.utils.ConsoleHelper.cprint(message, **level_settings)
             self.flush()
         except Exception:  # pylint: disable=broad-except
             self.handleError(record)
@@ -153,6 +172,6 @@ logger = LoggerHelper.get_basic_logger('rebase-helper')
 logger_output = LoggerHelper.get_basic_logger('output-tool', logging.INFO)
 logger_report = LoggerHelper.get_basic_logger('rebase-helper-report', logging.INFO)
 logger_upstream = LoggerHelper.get_basic_logger('rebase-helper-upstream')
-LoggerHelper.add_stream_handler(logger_output)
+output_tool_handler = LoggerHelper.add_stream_handler(logger_output)
 formatter = logging.Formatter("%(levelname)s: %(message)s")
-handler = LoggerHelper.add_stream_handler(logger, logging.DEBUG, formatter)
+main_handler = LoggerHelper.add_stream_handler(logger, logging.DEBUG, formatter)

--- a/rebasehelper/logger.py
+++ b/rebasehelper/logger.py
@@ -28,11 +28,13 @@ import rebasehelper.utils
 
 class CustomLogger(logging.Logger):
 
+    TRACE = logging.DEBUG + 1
     SUCCESS = logging.INFO + 5
     HEADING = logging.INFO + 6
     IMPORTANT = logging.INFO + 7
 
     _nameToLevel = {
+        'TRACE': TRACE,
         'SUCCESS': SUCCESS,
         'HEADING': HEADING,
         'IMPORTANT': IMPORTANT,
@@ -125,6 +127,7 @@ class LoggerHelper(object):
 class ColorizingStreamHandler(logging.StreamHandler):
     level_map = {
         logging.DEBUG: {'fg': 'brightblack', 'bg': 'default', 'style': None},
+        CustomLogger.TRACE: {'fg': 'red', 'bg': 'default', 'style': None},
         logging.INFO: {'fg': 'default', 'bg': 'default', 'style': None},
         CustomLogger.SUCCESS: {'fg': 'green', 'bg': 'default', 'style': None},
         CustomLogger.HEADING: {'fg': 'yellow', 'bg': 'default', 'style': None},

--- a/rebasehelper/logger.py
+++ b/rebasehelper/logger.py
@@ -152,8 +152,11 @@ class ColorizingStreamHandler(logging.StreamHandler):
 
     terminal_background = 'dark'
 
-    def set_terminal_background(self):
-        self.terminal_background = rebasehelper.utils.ConsoleHelper.detect_background()
+    def set_terminal_background(self, background):
+        if background == 'auto':
+            self.terminal_background = rebasehelper.utils.ConsoleHelper.detect_background()
+        else:
+            self.terminal_background = background
 
     def emit(self, record):
         try:

--- a/rebasehelper/options.py
+++ b/rebasehelper/options.py
@@ -55,6 +55,12 @@ OPTIONS = [
         "name": ["--results-dir"],
         "help": "directory where rebase-helper output will be stored",
     },
+    {
+        "name": ["--background"],
+        "choices": ["dark", "light", "auto"],
+        "default": "auto",
+        "help": "change color scheme, defaults to %(default)s",
+    },
     # action control
     [
         {

--- a/rebasehelper/tests/test_utils.py
+++ b/rebasehelper/tests/test_utils.py
@@ -150,6 +150,34 @@ class TestConsoleHelper(object):
         assert capturer.stdout == 'test stdout'
         assert capturer.stderr == 'test stderr'
 
+    @pytest.mark.parametrize('specification, expected_rgb, expected_bit_width', [
+        ('rgb:0000/0000/0000', (0x0, 0x0, 0x0), 16),
+        ('rgb:ffff/ffff/ffff', (0xffff, 0xffff, 0xffff), 16),
+        ('rgb:f/f/f', (0xf, 0xf, 0xf), 4),
+        ('rgb:', None, None)
+    ], ids=[
+        '16-bit-black',
+        '16-bit-white',
+        '4-bit-white',
+        'invalid-format',
+    ])
+    def test_parse_rgb_device_specification(self, specification, expected_rgb, expected_bit_width):
+        rgb, bit_width = ConsoleHelper.parse_rgb_device_specification(specification)
+        assert rgb == expected_rgb
+        assert bit_width == expected_bit_width
+
+    @pytest.mark.parametrize('rgb_tuple, bit_width, expected_result', [
+        ((0xf, 0xf, 0xf), 4, True),
+        ((0x0, 0x0, 0x0), 4, False),
+        ((0x2929, 0x2929, 0x2929), 16, False),
+    ], ids=[
+        'white',
+        'black',
+        'grey',
+    ])
+    def test_color_is_light(self, rgb_tuple, bit_width, expected_result):
+        assert ConsoleHelper.color_is_light(rgb_tuple, bit_width) == expected_result
+
 
 class TestDownloadHelper(object):
     """ DownloadHelper tests """

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -21,27 +21,32 @@
 #          Tomas Hozza <thozza@redhat.com>
 
 import argparse
-import io
-import os
-import re
-import sys
+import datetime
+import fcntl
 import fnmatch
-import subprocess
-import tempfile
-import shutil
-import rpm
-import locale
-import time
-import random
-import string
+import io
 import gzip
-import copr
-import pyquery
 import hashlib
-import requests
+import locale
+import os
+import random
+import re
+import shutil
+import string
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+import tty
 
+import copr
 import git
+import pyquery
+import requests
+import rpm
 import six
+
 from six.moves import input
 from six.moves import urllib
 from six.moves import configparser
@@ -143,6 +148,103 @@ class ConsoleHelper(object):
                 print(message)
         else:
             print(message)
+
+    @staticmethod
+    def parse_rgb_device_specification(specification):
+        """Parses RGB device specification.
+
+        Args:
+            specification(str): RGB device specification.
+
+        Returns:
+            tuple: If the specification follows correct format, the first element is RGB tuple and the second is
+            bit width of the RGB. Otherwise, both elements are None.
+
+        """
+        match = re.match(r'^rgb:([A-Fa-f0-9]{1,4})/([A-Fa-f0-9]{1,4})/([A-Fa-f0-9]{1,4})$', str(specification))
+        if match:
+            rgb = match.groups()
+            bit_width = max([len(str(x)) for x in rgb]) * 4
+            return tuple(int(x, 16) for x in rgb), bit_width
+        return None, None
+
+    @staticmethod
+    def color_is_light(rgb, bit_width):
+        """Determines whether a color is light or dark.
+
+        Args:
+            rgb(tuple): RGB tuple.
+            bit_width: Number of bits defining the RGB.
+
+        Returns:
+            bool: Whether a color is light or dark.
+
+        """
+        brightness = 1 - (0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2]) / (1 << bit_width - 1)
+        return brightness < 0.5
+
+    @staticmethod
+    def detect_background():
+        """Detects terminal background color and decides whether it is light or dark.
+
+        Returns:
+            str: Whether to use dark or light color scheme.
+
+        """
+        background_color = ConsoleHelper.exchange_control_sequence('\x1b]11;?\x07')
+
+        rgb_tuple, bit_width = ConsoleHelper.parse_rgb_device_specification(background_color)
+
+        if rgb_tuple and ConsoleHelper.color_is_light(rgb_tuple, bit_width):
+            return 'light'
+        else:
+            return 'dark'
+
+    @staticmethod
+    def exchange_control_sequence(query, timeout=0.05):
+        """Captures a response of a control sequence from STDIN.
+
+        Args:
+            query (str): Control sequence.
+            timeout (int, float): Time given to the terminal to react.
+
+        Returns:
+            str: Response of the terminal.
+
+        """
+        prefix, suffix = query.split('?', 1)
+        attrs_obtained = False
+        try:
+            attrs = termios.tcgetattr(sys.stdin)
+            attrs_obtained = True
+            flags = fcntl.fcntl(sys.stdin.fileno(), fcntl.F_GETFL)
+
+            # disable STDIN line buffering
+            tty.setcbreak(sys.stdin.fileno(), termios.TCSANOW)
+            # set STDIN to non-blocking mode
+            fcntl.fcntl(sys.stdin.fileno(), fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+            sys.stdout.write(query)
+            sys.stdout.flush()
+
+            # read the response
+            buf = ''
+            start = datetime.datetime.now()
+            while (datetime.datetime.now() - start).total_seconds() < timeout:
+                try:
+                    buf += sys.stdin.read(1)
+                except IOError:
+                    continue
+                if buf.endswith(suffix):
+                    return buf.replace(prefix, '').replace(suffix, '')
+            return None
+        except termios.error:
+            return None
+        finally:
+            # set terminal settings to the starting point
+            if attrs_obtained:
+                termios.tcsetattr(sys.stdin, termios.TCSADRAIN, attrs)
+                fcntl.fcntl(sys.stdin.fileno(), fcntl.F_SETFL, flags)
 
     @staticmethod
     def get_message(message, default_yes=True, any_input=False):

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -101,7 +101,15 @@ class ConsoleHelper(object):
 
     @classmethod
     def should_use_colors(cls, conf):
-        """Determine whether ansi colors should be used for CLI output"""
+        """Determines whether ANSI colors should be used for CLI output.
+
+        Args:
+            conf (rebasehelper.config.Config): Configuration object with arguments from the command line.
+
+        Returns:
+            bool: Whether colors should be used.
+
+        """
         if os.environ.get('PY_COLORS') == '1':
             return True
         if os.environ.get('PY_COLORS') == '0':
@@ -115,27 +123,39 @@ class ConsoleHelper(object):
         return True
 
     @classmethod
-    def cprint(cls, message, color=None):
-        """
-        Print colored output if possible
+    def cprint(cls, message, fg=None, bg=None, style=None):
+        """Prints colored output if possible.
 
-        :param color: color to be used in the output
-        :param message: string to be printed out
+        Args:
+            message (str): String to be printed out.
+            fg (str): Foreground color.
+            bg (str): Background color.
+            style (str): Style to be applied to the printed message.
+                Possible styles: bold, faint, italic, underline, blink, blink2, negative, concealed, crossed.
+                Some styles may not be supported by every terminal, e.g. 'blink'.
+                Multiple styles should be connected with a '+', e.g. 'bold+italic'.
+
         """
-        if cls.use_colors and color is not None and hasattr(colors, color):
-            print(getattr(colors, color)(message))
+        if cls.use_colors:
+            try:
+                print(colors.color(message, fg=fg, bg=bg, style=style))
+            except ValueError:
+                print(message)
         else:
             print(message)
 
     @staticmethod
     def get_message(message, default_yes=True, any_input=False):
-        """
-        Function for command line messages
+        """Prompts a user with yes/no message and gets the response.
 
-        :param message: prompt string
-        :param default_yes: If the default value is YES
-        :param any_input: if True, return input without checking it first
-        :return: True or False, based on user's input
+        Args:
+            message (str): Prompt string.
+            default_yes (bool): If the default value should be YES.
+            any_input (bool): Whether to return default value regardless of input.
+
+        Returns:
+            bool: True or False, based on user's input.
+
         """
         if default_yes:
             choice = '[Y/n]'

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,11 @@ setup(
     },
     install_requires=get_requirements(),
     setup_requires=[],
+    # this is only a temporary change until the PR adding bright colors support isn't merged to upstream
+    # link to the PR: https://github.com/jonathaneunice/colors/pull/1
+    dependency_links=[
+        'git+https://github.com/FrNecas/colors.git@#egg=ansicolors'
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Colorize console output using ColorizingStreamHandler.
Also, use formatter to display logging level in the output.

There are now 2 color maps, they can be either switched manually or rebase-helper can decide which one to use depending on the background color of the terminal.

4 new logging levels have been added 
- SUCCESS for successful operations (colored to green)
- HEADING for separating individual sections of output ( colored to blue/yellow)
- IMPORTANT to highlight important messages (colored to red)
- TRACE to differentiate between traceback and debug messages (colored to red)