### PR TITLE
Get potentially missing package signing key

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,6 +1,9 @@
 ARG BASE_IMAGE=fedora:latest
 FROM ${BASE_IMAGE}
 
+COPY docker/getkey.sh /getkey.sh
+RUN /getkey.sh && rm -f /getkey.sh
+
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf \
   && dnf -y update \
   && dnf -y install \

--- a/docker/getkey.sh
+++ b/docker/getkey.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# try to get GPG package signing key of an upcoming Fedora release
+# to prevent package installation failures
+
+. /etc/os-release
+
+version="$((VERSION_ID + 1))"
+filename="RPM-GPG-KEY-fedora-${version}-primary"
+url="https://pagure.io/fedora-repos/raw/master/f/${filename}"
+destination="/etc/pki/rpm-gpg/${filename}"
+
+if [ ! -f "${destination}" ] && curl --head --fail --url "${url}"; then
+    curl --url "${url}" --output "${destination}"
+    rpm --import "${destination}"
+fi


### PR DESCRIPTION
Before beta freeze of a Fedora release it can happen that some packages are already signed with a GPG key of that release, but the key is not yet installed as part of fedora-repos package.

Try to download and install such key from upstream repository in base image to prevent installation failures.