### PR TITLE
 Add CLI option for applying changes patch

### DIFF
--- a/rebasehelper/options.py
+++ b/rebasehelper/options.py
@@ -159,6 +159,12 @@ OPTIONS = [
         "help": "do not remove workspace directory after finishing",
     },
     {
+        "name": ["--apply-changes"],
+        "default": False,
+        "switch": True,
+        "help": "apply changes.patch after a successful rebase",
+    },
+    {
         "name": ["--disable-inapplicable-patches"],
         "default": False,
         "switch": True,


### PR DESCRIPTION
After a successful rebase, there is now a possibility to apply the `changes.patch` as a commit to the `dist-git`.

Implements one of the steps towards complete automation mentioned in #462.