### PR TITLE
Fix ABIPkgDiff report file generation

### DIFF
--- a/rebasehelper/checker.py
+++ b/rebasehelper/checker.py
@@ -30,7 +30,14 @@ from rebasehelper.constants import RESULTS_DIR
 
 
 class BaseChecker(object):
-    """ Base class used for testing tool run on final pkgs. """
+    """Base class of package checkers.
+
+    Attributes:
+        NAME(str): Name of the checker.
+        DEFAULT(bool): If True, the checker is run by default.
+        CATEGORY(str): Category which determines when the checker is run. Valid options: SRPM/RPM/SOURCE.
+        results_dir(str): Path where the results are stored.
+    """
 
     NAME = None
     DEFAULT = False

--- a/rebasehelper/checker.py
+++ b/rebasehelper/checker.py
@@ -41,7 +41,7 @@ class BaseChecker(object):
 
     NAME = None
     DEFAULT = False
-    category = None
+    CATEGORY = None
     results_dir = None
 
     @classmethod
@@ -76,7 +76,7 @@ class BaseChecker(object):
 
     @classmethod
     def get_category(cls):
-        return cls.category
+        return cls.CATEGORY
 
     @classmethod
     def get_underlined_title(cls, text, separator='='):

--- a/rebasehelper/checkers/abipkgdiff_tool.py
+++ b/rebasehelper/checkers/abipkgdiff_tool.py
@@ -35,7 +35,11 @@ from rebasehelper.checker import BaseChecker
 
 
 class AbiCheckerTool(BaseChecker):
-    """abipkgdiff compare tool"""
+    """abipkgdiff compare tool
+
+    Attributes:
+        abi_changes(bool): True if ABI changes were detected.
+    """
 
     NAME = "abipkgdiff"
     DEFAULT = True
@@ -43,8 +47,7 @@ class AbiCheckerTool(BaseChecker):
     ABIDIFF_USAGE_ERROR = 2
     abi_changes = None
     results_dir = ''
-    log_name = 'abipkgdiff.log'
-    category = 'RPM'
+    CATEGORY = 'RPM'
 
     # Example
     # abipkgdiff --d1 dbus-glib-debuginfo-0.80-3.fc12.x86_64.rpm \
@@ -120,10 +123,33 @@ class AbiCheckerTool(BaseChecker):
 
     @classmethod
     def parse_abi_logs(cls, reports):
-        """
-        Parse abipkgdiff logs
-        :param reports: dictionary with paths to the logs of the produced (sub)packages
-        :return: returns dict of packages names with its abipkgdiff changes
+        """Parses summary information from abipkgdiff logs.
+
+        Sets abi_changes attribute if there are any ABI changes found.
+
+        Args:
+            reports(dict): Dictionary mapping package names to abipkgdiff return codes.
+
+        Returns:
+            dict: Dictionary mapping package names to a dict of summary information for each shared object.
+
+            For example:
+
+            {
+                'libtiff':
+                {
+                   'libtiff.so.5.2.5':{
+                        'Functions changes summary': {
+                            'Added': {
+                                'count': '8',
+                                'what': 'Added',
+                                'filtered_out': None,
+                            },
+                        },
+                        'Variables changes summary': {},
+                    },
+                },
+            }
         """
         def parse_changes(lines):
             title_re = re.compile(r"^\s*=+\s*changes\s+of\s+'(?P<filename>.+)'.*$")
@@ -168,14 +194,9 @@ class AbiCheckerTool(BaseChecker):
 
     @classmethod
     def format(cls, data):
-        """
-        Format abipkgdiff output
-        :param data: abipkgdiff dictionary output
-        :return: formated abipkgdiff list of strings
-        """
         output_lines = [cls.get_underlined_title('abipkgdiff')]
         if not data['abi_changes']:
-            output_lines.append('No ABI changes occured')
+            output_lines.append('No ABI changes occured.')
             return output_lines
         for pkg_name, pkg_changes in sorted(six.iteritems(data['packages'])):
             if not pkg_changes:
@@ -204,4 +225,4 @@ class AbiCheckerTool(BaseChecker):
     @classmethod
     def get_important_changes(cls, checker_output):
         if checker_output['abi_changes']:
-            return ['ABI changes occured. Check abipkgdiff output']
+            return ['ABI changes occured. Check abipkgdiff output.']

--- a/rebasehelper/checkers/abipkgdiff_tool.py
+++ b/rebasehelper/checkers/abipkgdiff_tool.py
@@ -126,14 +126,7 @@ class AbiCheckerTool(BaseChecker):
         :return: returns dict of packages names with its abipkgdiff changes
         """
         def parse_changes(lines):
-            """
-            Parses each line with abipkgdiff output info
-            :param lines: list of lines of changes
-            :return: dictionary of list of changes
-
-            Example abipkgdiff line:
-            '  Functions changes summary: 3 Removed, 0 Changed, 0 Added functions (4 filtered out)'
-            """
+            title_re = re.compile(r"^\s*=+\s*changes\s+of\s+'(?P<filename>.+)'.*$")
             summary_re = re.compile(r'''^
             \s+(?P<kind>[\w\s]+changes\s+summary):\s+
             (?P<changes>.+)
@@ -144,27 +137,33 @@ class AbiCheckerTool(BaseChecker):
             (?P<what>Added|Changed|Removed)(\s+functions|variables)?
             (\s+\((?P<filtered_out>\d+)\s+filtered\s+out\))?
             ''', re.VERBOSE)
-            result = {}
+            result_dict = {}
+            filename = 'Undetected filename'
             for line in lines:
+                mt = title_re.match(line)
+                if mt:
+                    filename = mt.group('filename')
+                    if filename not in result_dict:
+                        result_dict[filename] = {}
                 ms = summary_re.match(line)
                 if ms:
+                    result = {}
                     ds = ms.groupdict()
                     result[ds['kind']] = {}
                     for mc in changes_re.finditer(ds['changes']):
                         dc = mc.groupdict()
                         if int(dc['count']) or dc['filtered_out']:
                             result[ds['kind']][dc['what']] = dc
-            return result
+                    result_dict[filename].update(result)
+            return result_dict
 
         pkgs = {}
         for pkg, ret_code in six.iteritems(reports):
             # If no abi changes for the package, store empty dictionary
-            cur_pkg = {}
             if ret_code:
                 with open(os.path.join(cls.results_dir, pkg + '.txt'), 'r') as f:
-                    cur_pkg = parse_changes(f.readlines())
                     cls.abi_changes = True
-            pkgs[pkg] = cur_pkg
+                    pkgs[pkg] = parse_changes(f.readlines())
         return pkgs
 
     @classmethod
@@ -178,24 +177,24 @@ class AbiCheckerTool(BaseChecker):
         if not data['abi_changes']:
             output_lines.append('No ABI changes occured')
             return output_lines
-
         for pkg_name, pkg_changes in sorted(six.iteritems(data['packages'])):
             if not pkg_changes:
                 continue
             output_lines.append("ABI changes in {}:".format(pkg_name))
+            for filename, file_changes in six.iteritems(pkg_changes):
+                output_lines.append(" - {}:".format(filename))
+                for sum_title, changes_list in sorted(six.iteritems(file_changes)):
+                    if not changes_list:
+                        continue
+                    output_lines.append("   - {}:".format(sum_title))
 
-            for sum_title, changes_list in sorted(six.iteritems(pkg_changes)):
-                if not changes_list:
-                    continue
-                output_lines.append("{}".format(sum_title))
-
-                for change_name, change_info in sorted(six.iteritems(changes_list)):
-                    if change_info['filtered_out']:
-                        output_lines.append(" - {} {} (filtered out {})".format(change_name,
-                                                                                change_info['count'],
-                                                                                change_info['filtered_out']))
-                    else:
-                        output_lines.append(" - {} {}".format(change_name, change_info['count']))
+                    for change_name, change_info in sorted(six.iteritems(changes_list)):
+                        if change_info['filtered_out']:
+                            output_lines.append("     - {} {} (filtered out {})".format(change_name,
+                                                                                        change_info['count'],
+                                                                                        change_info['filtered_out']))
+                        else:
+                            output_lines.append("     - {} {}".format(change_name, change_info['count']))
         output_lines.append("Details in {}:".format(data['path']))
         for pkg_name, pkg_changes in sorted(six.iteritems(data['packages'])):
             output_lines.append(" - {}.txt".format(pkg_name))

--- a/rebasehelper/checkers/csmock_tool.py
+++ b/rebasehelper/checkers/csmock_tool.py
@@ -36,7 +36,7 @@ class CsmockTool(BaseChecker):
     """ Csmock compare tool."""
 
     NAME = "csmock"
-    category = "SRPM"
+    CATEGORY = "SRPM"
 
     @classmethod
     def run_check(cls, results_dir, **kwargs):

--- a/rebasehelper/checkers/licensecheck_tool.py
+++ b/rebasehelper/checkers/licensecheck_tool.py
@@ -39,7 +39,7 @@ class LicenseCheckTool(BaseChecker):
 
     NAME = "licensecheck"
     DEFAULT = True
-    category = "SOURCE"
+    CATEGORY = "SOURCE"
     license_changes = False
     license_files_changes = dict()
 

--- a/rebasehelper/checkers/pkgdiff_tool.py
+++ b/rebasehelper/checkers/pkgdiff_tool.py
@@ -42,7 +42,7 @@ class PkgDiffTool(BaseChecker):
     files_xml = "files.xml"
     results_dir = ''
     results_dict = {}
-    category = "RPM"
+    CATEGORY = "RPM"
 
     @classmethod
     def _get_rpm_info(cls, name, packages):

--- a/rebasehelper/checkers/rpmdiff_tool.py
+++ b/rebasehelper/checkers/rpmdiff_tool.py
@@ -39,7 +39,7 @@ class RpmDiffTool(BaseChecker):
     NAME = "rpmdiff"
     DEFAULT = True
     CHECKER_TAGS = ['added', 'removed', 'changed', 'moved', 'renamed']
-    category = "RPM"
+    CATEGORY = "RPM"
 
     @classmethod
     def _get_rpms(cls, rpm_list):


### PR DESCRIPTION
ABIPkgDiff now writes numbers from all detected ABI changes.
Example:
```
abipkgdiff
==========
ABI changes in pstoedit:
 - libp2edrvstd.so.0.0.0 - Functions changes summary
    - Changed 1 (filtered out 66)
    - Removed 0 (filtered out 14)
 - libpstoedit.so.0.0.0 - Functions changes summary
    - Added 3 (filtered out 2)
    - Changed 2 (filtered out 51)
    - Removed 1 (filtered out 10)
 - libpstoedit.so.0.0.0 - Variables changes summary
    - Changed 1 (filtered out 3)
 - libp2edrvwmf.so.0.0.0 - Functions changes summary
    - Changed 1 (filtered out 2)
 - libp2edrvlplot.so.0.0.0 - Functions changes summary
    - Changed 1 (filtered out 2)
    - Removed 0 (filtered out 2)
Details in rebase-helper-results/checkers/abipkgdiff:
 - pstoedit.txt
 - pstoedit-devel.txt
```
Fixes #489 