### PR TITLE
Enable --strategy-option for rebasing

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -93,6 +93,8 @@ class Application(object):
 
         self.kwargs['non_interactive'] = self.conf.non_interactive
 
+        self.kwargs['favor_on_conflict'] = self.conf.favor_on_conflict
+
         self.kwargs['changelog_entry'] = self.conf.changelog_entry
 
         self.kwargs['spec_hook_blacklist'] = self.conf.spec_hook_blacklist

--- a/rebasehelper/options.py
+++ b/rebasehelper/options.py
@@ -147,6 +147,13 @@ OPTIONS = [
         "help": "do not interact with user",
     },
     {
+        "name": ["--favor-on-conflict"],
+        "choices": ["downstream", "upstream", "off"],
+        "default": "off",
+        "dest": "favor_on_conflict",
+        "help": "favor downstream or upstream changes when conflicts appear",
+    },
+    {
         "name": ["--not-download-sources"],
         "default": False,
         "switch": True,

--- a/rebasehelper/patch_helper.py
+++ b/rebasehelper/patch_helper.py
@@ -145,8 +145,15 @@ class GitPatchTool(PatchBase):
             cls.old_repo.create_remote(upstream, url=cls.new_sources).fetch()
             root_commit = cls.old_repo.git.rev_list('HEAD', max_parents=0)
             last_commit = cls.old_repo.commit('HEAD')
+            if cls.favor_on_conflict == 'upstream':
+                strategy_option = 'ours'
+            elif cls.favor_on_conflict == 'downstream':
+                strategy_option = 'theirs'
+            else:
+                strategy_option = False
             try:
                 cls.output_data = cls.old_repo.git.rebase(root_commit, last_commit,
+                                                          strategy_option=strategy_option,
                                                           onto='{}/master'.format(upstream),
                                                           stdout_as_string=six.PY3)
             except git.GitCommandError as e:
@@ -279,6 +286,7 @@ class GitPatchTool(PatchBase):
         cls.rest_sources = rest_sources
         cls.patches = patches
         cls.non_interactive = kwargs.get('non_interactive')
+        cls.favor_on_conflict = kwargs.get('favor_on_conflict')
         if not os.path.isdir(os.path.join(cls.old_sources, '.git')):
             cls.old_repo = cls.init_git(old_dir)
             cls.new_repo = cls.init_git(new_dir)


### PR DESCRIPTION
"git rebase" --strategy-option makes use of prefering one or the other
sides that are being merged.
"upstream" in context of rebase-helper rebasing refers to the upstream code,
while "downstream" refers to the downstream code(with the downstream patches).

https://git-scm.com/docs/git-rebase#git-rebase--Xltstrategy-optiongt