### PR TITLE
Default to listing all argument choices, list available only on request

### DIFF
--- a/rebasehelper/build_helper.py
+++ b/rebasehelper/build_helper.py
@@ -27,7 +27,6 @@ import os
 import six
 import pkg_resources
 
-from rebasehelper.constants import DOCS_BUILD
 from rebasehelper.helpers.path_helper import PathHelper
 from rebasehelper.temporary_environment import TemporaryEnvironment
 from rebasehelper.logger import logger
@@ -390,10 +389,6 @@ class SRPMBuilder(object):
         return [entrypoint.name for entrypoint in pkg_resources.iter_entry_points('rebasehelper.srpm_build_tools')]
 
     @classmethod
-    def get_tools(cls):
-        return cls.get_all_tools() if DOCS_BUILD else cls.get_supported_tools()
-
-    @classmethod
     def get_default_tool(cls):
         """Returns default build tool"""
         default = [k for k, v in six.iteritems(cls.srpm_build_tools) if v.is_default()]
@@ -487,10 +482,6 @@ class Builder(object):
     def get_all_tools():
         """Returns a list of all build tools."""
         return [entrypoint.name for entrypoint in pkg_resources.iter_entry_points('rebasehelper.build_tools')]
-
-    @classmethod
-    def get_tools(cls):
-        return cls.get_all_tools() if DOCS_BUILD else cls.get_supported_tools()
 
     @classmethod
     def get_default_tool(cls):

--- a/rebasehelper/checker.py
+++ b/rebasehelper/checker.py
@@ -26,7 +26,7 @@ import os
 import six
 
 from rebasehelper.logger import logger
-from rebasehelper.constants import RESULTS_DIR, DOCS_BUILD
+from rebasehelper.constants import RESULTS_DIR
 
 
 class BaseChecker(object):
@@ -158,9 +158,6 @@ class CheckersRunner(object):
     def get_all_tools():
         """Returns a list of all checkers."""
         return [entrypoint.name for entrypoint in pkg_resources.iter_entry_points('rebasehelper.checkers')]
-
-    def get_tools(self):
-        return self.get_all_tools() if DOCS_BUILD else self.get_supported_tools()
 
     def get_default_tools(self):
         """Return list of default tools"""

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -42,13 +42,17 @@ class CLI(object):
     """ Class for processing data from commandline """
 
     @staticmethod
-    def build_parser():
+    def build_parser(available_choices_only=False):
         parser = CustomArgumentParser(description=PROGRAM_DESCRIPTION,
                                       formatter_class=CustomHelpFormatter)
 
         group = parser.add_mutually_exclusive_group()
         current_group = 0
         for option in traverse_options(OPTIONS):
+            available_choices = option.pop("available_choices", option.get("choices"))
+            if available_choices_only:
+                option["choices"] = available_choices
+
             option_kwargs = dict(option)
             for key in ("group", "default", "name"):
                 if key in option_kwargs:
@@ -81,7 +85,7 @@ class CLI(object):
                 args[i:i+2] = ['='.join(args[i:i+2])]
             except ValueError:
                 continue
-        self.parser = CLI.build_parser()
+        self.parser = CLI.build_parser(available_choices_only=True)
         self.args = self.parser.parse_args(args)
 
     def __getattr__(self, name):

--- a/rebasehelper/constants.py
+++ b/rebasehelper/constants.py
@@ -21,7 +21,6 @@
 #          Tomas Hozza <thozza@redhat.com>
 
 import locale
-import sys
 
 
 PROGRAM_DESCRIPTION = 'Tool to help package maintainers rebase their packages to the latest upstream version'
@@ -52,5 +51,3 @@ CONFIG_FILENAME = 'rebase-helper.cfg'
 
 DEFENC = locale.getpreferredencoding()
 DEFENC = 'utf-8' if DEFENC == 'ascii' else DEFENC
-
-DOCS_BUILD = 'sphinx' in sys.modules

--- a/rebasehelper/options.py
+++ b/rebasehelper/options.py
@@ -94,19 +94,22 @@ OPTIONS = [
     # tool selection
     {
         "name": ["--buildtool"],
-        "choices": Builder.get_tools(),
+        "choices": Builder.get_all_tools(),
+        "available_choices": Builder.get_supported_tools(),
         "default": Builder.get_default_tool(),
         "help": "build tool to use, defaults to %(default)s",
     },
     {
         "name": ["--srpm-buildtool"],
-        "choices": SRPMBuilder.get_tools(),
+        "choices": SRPMBuilder.get_all_tools(),
+        "available_choices": SRPMBuilder.get_supported_tools(),
         "default": SRPMBuilder.get_default_tool(),
         "help": "SRPM build tool to use, defaults to %(default)s",
     },
     {
         "name": ["--pkgcomparetool"],
-        "choices": checkers_runner.get_tools(),
+        "choices": checkers_runner.get_all_tools(),
+        "available_choices": checkers_runner.get_supported_tools(),
         "default": checkers_runner.get_default_tools(),
         "type": lambda s: s.split(','),
         "help": "set of tools to use for package comparison, defaults to "
@@ -114,27 +117,31 @@ OPTIONS = [
     },
     {
         "name": ["--outputtool"],
-        "choices": BaseOutputTool.get_tools(),
+        "choices": BaseOutputTool.get_all_tools(),
+        "available_choices": BaseOutputTool.get_supported_tools(),
         "default": BaseOutputTool.get_default_tool(),
         "help": "tool to use for formatting rebase output, defaults to %(default)s",
     },
     {
         "name": ["--versioneer"],
-        "choices": versioneers_runner.get_versioneers(),
+        "choices": versioneers_runner.get_all_versioneers(),
+        "available_choices": versioneers_runner.get_available_versioneers(),
         "default": None,
         "help": "tool to use for determining latest upstream version",
     },
     # blacklists
     {
         "name": ["--versioneer-blacklist"],
-        "choices": versioneers_runner.get_versioneers(),
+        "choices": versioneers_runner.get_all_versioneers(),
+        "available_choices": versioneers_runner.get_available_versioneers(),
         "default": [],
         "type": lambda s: s.split(","),
         "help": "prevent specified versioneers from being run",
     },
     {
         "name": ["--spec-hook-blacklist"],
-        "choices": spec_hooks_runner.get_spec_hooks(),
+        "choices": spec_hooks_runner.get_all_spec_hooks(),
+        "available_choices": spec_hooks_runner.get_available_spec_hooks(),
         "default": [],
         "type": lambda s: s.split(","),
         "help": "prevent specified spec hooks from being run",

--- a/rebasehelper/output_tool.py
+++ b/rebasehelper/output_tool.py
@@ -27,7 +27,7 @@ import pkg_resources
 from rebasehelper.logger import logger, logger_output
 from rebasehelper.results_store import results_store
 from rebasehelper.checker import checkers_runner
-from rebasehelper.constants import RESULTS_DIR, REPORT, DOCS_BUILD
+from rebasehelper.constants import RESULTS_DIR, REPORT
 
 
 class BaseOutputTool(object):
@@ -162,10 +162,6 @@ class BaseOutputTool(object):
     def get_all_tools():
         """Returns a list of all output tools."""
         return [entrypoint.name for entrypoint in pkg_resources.iter_entry_points('rebasehelper.output_tools')]
-
-    @classmethod
-    def get_tools(cls):
-        return cls.get_all_tools() if DOCS_BUILD else cls.get_supported_tools()
 
     @staticmethod
     def get_default_tool():

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -1507,9 +1507,6 @@ class SpecHooksRunner(object):
         """Returns a list of all spec hooks."""
         return [entrypoint.name for entrypoint in pkg_resources.iter_entry_points('rebasehelper.spec_hooks')]
 
-    def get_spec_hooks(self):
-        return self.get_all_spec_hooks() if constants.DOCS_BUILD else self.get_available_spec_hooks()
-
     def run_spec_hooks(self, spec_file, rebase_spec_file, **kwargs):
         """
         Runs all spec hooks.

--- a/rebasehelper/versioneer.py
+++ b/rebasehelper/versioneer.py
@@ -23,7 +23,6 @@
 import six
 import pkg_resources
 
-from rebasehelper.constants import DOCS_BUILD
 from rebasehelper.logger import logger
 
 
@@ -75,9 +74,6 @@ class VersioneersRunner(object):
     def get_all_versioneers():
         """Returns a list of all versioneers."""
         return [entrypoint.name for entrypoint in pkg_resources.iter_entry_points('rebasehelper.versioneers')]
-
-    def get_versioneers(self):
-        return self.get_all_versioneers() if DOCS_BUILD else self.get_available_versioneers()
 
     def run(self, versioneer, package_name, category, versioneer_blacklist=None):
         """


### PR DESCRIPTION
It is necessary to list all argument choices when generating documentation, bash completion data or sample configuration.

List all argument choices by default, and list just those available only when running rebase-helper directly.