### PR TITLE
Get rid of unversioned python command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON = python
+PYTHON = python3
 
 
 all: help

--- a/rebase-helper.py
+++ b/rebase-helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # This tool helps you to rebase package to the latest version
@@ -22,6 +22,7 @@
 #          Tomas Hozza <thozza@redhat.com>
 
 import sys
+
 from rebasehelper.cli import CliHelper
 
 if __name__ == "__main__":


### PR DESCRIPTION
Starting with Fedora 29, there is no unversioned `python` command installed by default. There is no real reason not to use `/usr/bin/python3` instead of `/usr/bin/python`.
