### PR TITLE
Add --skip-upload option

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -119,7 +119,8 @@ class Application(object):
                 rebased_sources = [os.path.basename(s) for s in self.rebase_spec_file.sources]
                 uploaded = LookasideCacheHelper.update_sources('fedpkg', self.rebased_sources_dir,
                                                                self.rebase_spec_file.get_package_name(),
-                                                               sources, rebased_sources)
+                                                               sources, rebased_sources,
+                                                               upload=not self.conf.skip_upload)
                 self._update_gitignore(uploaded, self.rebased_sources_dir)
 
             # TODO: Remove the value from kwargs and use only CLI attribute!

--- a/rebasehelper/helpers/lookaside_cache_helper.py
+++ b/rebasehelper/helpers/lookaside_cache_helper.py
@@ -179,7 +179,7 @@ class LookasideCacheHelper(object):
             sys.stdout.flush()
 
     @classmethod
-    def update_sources(cls, tool, basepath, package, old_sources, new_sources):
+    def update_sources(cls, tool, basepath, package, old_sources, new_sources, upload=True):
         try:
             config = cls._read_config(tool)
             url = config['lookaside_cgi']
@@ -196,7 +196,8 @@ class LookasideCacheHelper(object):
                     # no change
                     continue
                 hsh = cls._hash(filename, hashtype)
-                cls._upload_source(url, package, filename, hashtype, hsh)
+                if upload:
+                    cls._upload_source(url, package, filename, hashtype, hsh)
                 uploaded.append(filename)
                 sources[indexes[0]] = dict(hash=hsh, filename=filename, hashtype=hashtype)
         cls._write_sources(basepath, sources)

--- a/rebasehelper/options.py
+++ b/rebasehelper/options.py
@@ -214,6 +214,12 @@ OPTIONS = [
         "help": "update \"sources\" file and upload new sources to lookaside cache",
     },
     {
+        "name": ["--skip-upload"],
+        "default": False,
+        "switch": True,
+        "help": "skip uploading new sources to lookaside cache",
+    },
+    {
         "name": ["--force-build-log-hooks"],
         "default": False,
         "switch": True,


### PR DESCRIPTION
There is no need to upload sources to lookaside cache again if one wants to *replay* past rebase.