### PR TITLE
Fix ruby-helper spec hook

### DIFF
--- a/rebasehelper/spec_hooks/ruby_helper.py
+++ b/rebasehelper/spec_hooks/ruby_helper.py
@@ -56,7 +56,7 @@ class RubyHelperHook(BaseSpecHook):
             script = os.path.join(tmp.path(), 'script.sh')
             with open(script, 'w') as f:
                 f.write('#!/bin/sh -x\n')
-                f.write(''.join(instructions))
+                f.write('{}\n'.format('\n'.join(instructions)))
                 f.write('cp "{}" "{}"\n'.format(source, os.getcwd()))
             os.chmod(script, 0o755)
             result = ProcessHelper.run_subprocess_cwd(script, tmp.path(), output_file=logfile, shell=True)

--- a/rebasehelper/spec_hooks/ruby_helper.py
+++ b/rebasehelper/spec_hooks/ruby_helper.py
@@ -88,6 +88,9 @@ class RubyHelperHook(BaseSpecHook):
                             comments = rebase_spec_file.spec_content.sections['%package'][j+1:i]
                             break
                     break
+            if not comments:
+                # nothing to do
+                continue
             # update data so that RPM macros are populated correctly
             rebase_spec_file._update_data()  # pylint: disable=protected-access
             instructions = cls._get_instructions(comments,


### PR DESCRIPTION
Introduction of `SpecContent` removed newlines from line items, so they need to be added when generating a script.