### PR TITLE
Only attempt Koji login if necessary

### DIFF
--- a/rebasehelper/build_tools/koji_tool.py
+++ b/rebasehelper/build_tools/koji_tool.py
@@ -78,7 +78,7 @@ class KojiBuildTool(BuildToolBase):
 
     @classmethod
     def _scratch_build(cls, srpm, **kwargs):
-        session = KojiHelper.create_session()
+        session = KojiHelper.create_session(login=True)
         remote = KojiHelper.upload_srpm(session, srpm)
         task_id = session.build(remote, cls.target_tag, dict(scratch=True))
         if kwargs['builds_nowait']:

--- a/rebasehelper/helpers/koji_helper.py
+++ b/rebasehelper/helpers/koji_helper.py
@@ -50,10 +50,11 @@ class KojiHelper(object):
     functional = koji_helper_functional
 
     @classmethod
-    def create_session(cls, profile='koji'):
+    def create_session(cls, login=False, profile='koji'):
         """Creates new Koji session and immediately logs in to a Koji hub.
 
         Args:
+            login (bool): Whether to perform a login.
             profile (str): Koji profile to use.
 
         Returns:
@@ -65,6 +66,8 @@ class KojiHelper(object):
         """
         config = koji.read_config(profile)
         session = koji.ClientSession(config['server'], opts=config)
+        if not login:
+            return session
         try:
             session.gssapi_login()
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Downloading builds and logs from Koji, as well as querying task info doesn't require login. Don't attempt to log-in in such cases, to allow users without FAS to use `--get-old-build-from-koji` option.

Fixes #567.