### PR TITLE
spec,copy: handle new_path=None

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -1206,13 +1206,15 @@ class SpecFile(object):
     def copy(self, new_path=None):
         """
         Create a copy of the current object and copy the SPEC file the new object
-        represents to a new location.
+        represents to a new location. If new_path is not set, utilize the current path
 
         :param new_path: new path to which to copy the SPEC file
         :return: copy of the current object
         """
         if new_path:
             shutil.copy(self.path, new_path)
+        else:
+            new_path = self.path
         new_object = SpecFile(new_path, self.changelog_entry, self.sources_location, self.download)
         return new_object
 


### PR DESCRIPTION
```
  File "/home/tt/g/user-cont/packit/packit/upstream.py", line 238, in set_spec_version                                                                                      
    self._specfile = self.specfile.copy()
  File "/usr/lib/python3.7/site-packages/rebasehelper/specfile.py", line 1214, in copy                                                                                      
    new_object = SpecFile(new_path, self.changelog_entry, self.sources_location, self.download)                                                                             
  File "/usr/lib/python3.7/site-packages/rebasehelper/specfile.py", line 206, in __init__                                                                                   
    self._read_spec_content()
  File "/usr/lib/python3.7/site-packages/rebasehelper/specfile.py", line 1189, in _read_spec_content                                                                        
    with open(self.path) as f:
TypeError: expected str, bytes or os.PathLike object, not NoneType
```