### PR TITLE
Refactor how adding changelog entries works

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -188,7 +188,6 @@ class Application(object):
         self.rebase_spec_file_path = get_rebase_name(self.rebased_sources_dir, self.spec_file_path)
 
         self.spec_file = SpecFile(self.spec_file_path,
-                                  self.conf.changelog_entry,
                                   self.execution_dir,
                                   download=not self.conf.not_download_sources)
         # Check whether test suite is enabled at build time
@@ -228,7 +227,7 @@ class Application(object):
                 <= parse_version(self.spec_file.get_version()):
             raise RebaseHelperError("Current version is equal to or newer than the requested version, nothing to do.")
 
-        self.rebase_spec_file.update_changelog()
+        self.rebase_spec_file.update_changelog(self.conf.changelog_entry)
 
         # run spec hooks
         spec_hooks_runner.run_spec_hooks(self.spec_file, self.rebase_spec_file, **self.kwargs)

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -73,7 +73,7 @@ class TestSpecFile(object):
 
     @pytest.fixture
     def spec_object(self, workdir):
-        sf = SpecFile(self.SPEC_FILE, 'Update to %{version}', workdir, download=False)
+        sf = SpecFile(self.SPEC_FILE, workdir, download=False)
         return sf
 
     def test_get_release(self, spec_object):


### PR DESCRIPTION
Changelog_entry isn't now passed into the constructor of a SpecFile which should make it more logical to use.

Any objections @TomasTomecek , does this suit your use-case better?