### PR TITLE
Do not use dict to store spec sections

### DIFF
--- a/rebasehelper/build_log_hooks/files_build_log_hook.py
+++ b/rebasehelper/build_log_hooks/files_build_log_hook.py
@@ -172,7 +172,7 @@ class FilesBuildLogHook(BaseBuildLogHook):
         """
         best_match = ''
         best_match_section = ''
-        for sec_name, sec_content in six.iteritems(rebase_spec_file.spec_content.sections):
+        for sec_name, sec_content in rebase_spec_file.spec_content.sections:
             if sec_name.startswith('%files'):
                 for line in sec_content:
                     new_best_match = difflib.get_close_matches(file, [best_match, MacroHelper.expand(line)])
@@ -201,11 +201,11 @@ class FilesBuildLogHook(BaseBuildLogHook):
             section = cls._get_best_matching_files_section(rebase_spec_file, file)
             substituted_path = MacroHelper.substitute_path_with_macros(file, macros)
             try:
-                index = [i for i, l in enumerate(rebase_spec_file.spec_content.sections[section]) if l][-1] + 1
+                index = [i for i, l in enumerate(rebase_spec_file.spec_content.section(section)) if l][-1] + 1
             except IndexError:
                 # section is empty
                 index = 0
-            rebase_spec_file.spec_content.sections[section].insert(index, substituted_path)
+            rebase_spec_file.spec_content.section(section).insert(index, substituted_path)
             result['added'][section].append(substituted_path)
             logger.info("Added %s to '%s' section", substituted_path, section)
 
@@ -219,7 +219,7 @@ class FilesBuildLogHook(BaseBuildLogHook):
 
         """
         result = collections.defaultdict(lambda: collections.defaultdict(list))
-        for sec_name, sec_content in six.iteritems(rebase_spec_file.spec_content.sections):
+        for sec_name, sec_content in rebase_spec_file.spec_content.sections:
             if sec_name.startswith('%files'):
                 subpackage = rebase_spec_file.get_subpackage_name(sec_name)
                 i = 0
@@ -261,9 +261,9 @@ class FilesBuildLogHook(BaseBuildLogHook):
                             j += 1
 
                     if not split_line:
-                        del rebase_spec_file.spec_content.sections[sec_name][i]
+                        del sec_content[i]
                     else:
-                        rebase_spec_file.spec_content.sections[sec_name][i] = ' '.join(original_line)
+                        sec_content[i] = ' '.join(original_line)
                         i += 1
 
                     if not files:

--- a/rebasehelper/spec_hooks/commit_hash_updater.py
+++ b/rebasehelper/spec_hooks/commit_hash_updater.py
@@ -112,6 +112,6 @@ class CommitHashUpdaterHook(BaseSpecHook):
                 return
             source = source.replace(hashes[0], new_commit)
         tag = 'Source0'
-        if [l for l in rebase_spec_file.spec_content.sections['%package'] if re.match(r'^Source\s*:.*', l)]:
+        if [l for l in rebase_spec_file.spec_content.section('%package') if re.match(r'^Source\s*:.*', l)]:
             tag = 'Source'
         rebase_spec_file.set_tag(tag, source, preserve_macros=True)

--- a/rebasehelper/spec_hooks/escape_macros.py
+++ b/rebasehelper/spec_hooks/escape_macros.py
@@ -24,8 +24,6 @@
 
 import re
 
-import six
-
 from rebasehelper.specfile import BaseSpecHook
 
 
@@ -53,6 +51,6 @@ class EscapeMacrosHook(BaseSpecHook):
 
     @classmethod
     def run(cls, spec_file, rebase_spec_file, **kwargs):
-        for sec_name, sec_content in six.iteritems(rebase_spec_file.spec_content.sections):
-            for index, line in enumerate(sec_content):
-                rebase_spec_file.spec_content.sections[sec_name][index] = cls._escape_macros_in_comment(line)
+        for _, section in rebase_spec_file.spec_content.sections:
+            for index, line in enumerate(section):
+                section[index] = cls._escape_macros_in_comment(line)

--- a/rebasehelper/spec_hooks/paths_to_rpm_macros.py
+++ b/rebasehelper/spec_hooks/paths_to_rpm_macros.py
@@ -22,8 +22,6 @@
 #          Nikola Forró <nforro@redhat.com>
 #          František Nečas <fifinecas@seznam.cz>
 
-import six
-
 from rebasehelper.specfile import BaseSpecHook
 from rebasehelper.helpers.macro_helper import MacroHelper
 
@@ -38,9 +36,9 @@ class PathsToRPMMacrosHook(BaseSpecHook):
         # ensure maximal greediness
         macros.sort(key=lambda k: len(k['value']), reverse=True)
 
-        for sec_name, sec_content in six.iteritems(rebase_spec_file.spec_content.sections):
+        for sec_name, sec_content in rebase_spec_file.spec_content.sections:
             if sec_name.startswith('%files'):
                 for index, line in enumerate(sec_content):
                     new_path = MacroHelper.substitute_path_with_macros(line, macros)
-                    rebase_spec_file.spec_content.sections[sec_name][index] = new_path
+                    sec_content[index] = new_path
         rebase_spec_file.save()

--- a/rebasehelper/spec_hooks/pypi_url_fix.py
+++ b/rebasehelper/spec_hooks/pypi_url_fix.py
@@ -46,11 +46,12 @@ class PyPIURLFixHook(BaseSpecHook):
 
     @classmethod
     def run(cls, spec_file, rebase_spec_file, **kwargs):
-        for index, line in enumerate(rebase_spec_file.spec_content.sections['%package']):
+        preamble = rebase_spec_file.spec_content.section('%package')
+        for index, line in enumerate(preamble):
             if line.startswith("URL"):
-                rebase_spec_file.spec_content.sections['%package'][index] = cls._transform_url(line)
+                preamble[index] = cls._transform_url(line)
             elif line.startswith("Source"):
-                rebase_spec_file.spec_content.sections['%package'][index] = cls._transform_sources_url(line)
+                preamble[index] = cls._transform_sources_url(line)
         rebase_spec_file.save()
 
     @classmethod

--- a/rebasehelper/spec_hooks/replace_old_version.py
+++ b/rebasehelper/spec_hooks/replace_old_version.py
@@ -20,8 +20,6 @@
 # Authors: Petr Hracek <phracek@redhat.com>
 #          Tomas Hozza <thozza@redhat.com>
 
-import six
-
 from rebasehelper.specfile import BaseSpecHook
 
 
@@ -53,8 +51,8 @@ class ReplaceOldVersionSpecHook(BaseSpecHook):
     def run(cls, spec_file, rebase_spec_file, **kwargs):
         old_version = spec_file.get_version()
         new_version = rebase_spec_file.get_version()
-        for sec_name, sec_content in six.iteritems(rebase_spec_file.spec_content.sections):
-            for index, line in enumerate(sec_content):
-                rebase_spec_file.spec_content.sections[sec_name][index] = cls._replace(line, old_version, new_version)
+        for _, section in rebase_spec_file.spec_content.sections:
+            for index, line in enumerate(section):
+                section[index] = cls._replace(line, old_version, new_version)
 
         rebase_spec_file.save()

--- a/rebasehelper/spec_hooks/ruby_helper.py
+++ b/rebasehelper/spec_hooks/ruby_helper.py
@@ -82,12 +82,13 @@ class RubyHelperHook(BaseSpecHook):
             comment_re = re.compile(r'^#')
             comments = None
             # find matching Source line in the SPEC file
-            for i in range(len(rebase_spec_file.spec_content.sections['%package'])):
-                if source_re.match(rebase_spec_file.spec_content.sections['%package'][i]):
+            preamble = rebase_spec_file.spec_content.section('%package')
+            for i in range(len(preamble)):
+                if source_re.match(preamble[i]):
                     # get all comments above this line
                     for j in range(i - 1, 0, -1):
-                        if not comment_re.match(rebase_spec_file.spec_content.sections['%package'][j]):
-                            comments = rebase_spec_file.spec_content.sections['%package'][j+1:i]
+                        if not comment_re.match(preamble[j]):
+                            comments = preamble[j+1:i]
                             break
                     break
             if not comments:

--- a/rebasehelper/spec_hooks/typo_fix.py
+++ b/rebasehelper/spec_hooks/typo_fix.py
@@ -39,9 +39,9 @@ class TypoFixHook(BaseSpecHook):
 
     @classmethod
     def run(cls, spec_file, rebase_spec_file, **kwargs):
-        for section in rebase_spec_file.spec_content.sections:
-            for index, line in enumerate(rebase_spec_file.spec_content.sections[section]):
+        for _, section in rebase_spec_file.spec_content.sections:
+            for index, line in enumerate(section):
                 for replacement in cls.REPLACEMENTS:
                     line = re.sub(replacement[0], replacement[1], line)
-                rebase_spec_file.spec_content.sections[section][index] = line
+                section[index] = line
         rebase_spec_file.save()

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -201,7 +201,7 @@ class TestSpecFile(object):
 
     def test_set_extra_version_some_extra_version(self, spec_object):
         spec_object.set_extra_version('b1')
-        preamble = spec_object.spec_content.sections['%package']
+        preamble = spec_object.spec_content.section('%package')
         assert preamble[0] == '%global REBASE_EXTRA_VER b1'
         assert preamble[1] == '%global REBASE_VER %{version}%{REBASE_EXTRA_VER}'
         old_source_index = preamble.index('#Source: ftp://ftp.test.org/%{name}-%{version}.tar.xz')
@@ -215,14 +215,14 @@ class TestSpecFile(object):
 
     def test_set_extra_version_no_extra_version(self, spec_object):
         spec_object.set_extra_version('')
-        assert spec_object.spec_content.sections['%package'][0] != '%global REBASE_EXTRA_VER b1'
-        assert spec_object.spec_content.sections['%package'][1] != '%global REBASE_VER %{version}%{REBASE_EXTRA_VER}'
+        assert spec_object.spec_content.section('%package')[0] != '%global REBASE_EXTRA_VER b1'
+        assert spec_object.spec_content.section('%package')[1] != '%global REBASE_VER %{version}%{REBASE_EXTRA_VER}'
         assert spec_object.get_release_number() == '1'
 
     def test_redefine_release_with_macro(self, spec_object):
         macro = '%{REBASE_VER}'
         spec_object.redefine_release_with_macro(macro)
-        preamble = spec_object.spec_content.sections['%package']
+        preamble = spec_object.spec_content.section('%package')
         old_release_index = preamble.index('#Release: %{release_str}')
         assert preamble[old_release_index + 1] == 'Release: 34' + '.' + macro + '%{?dist}'
 
@@ -230,7 +230,7 @@ class TestSpecFile(object):
         macro = '%{REBASE_VER}'
         spec_object.redefine_release_with_macro(macro)
         spec_object.revert_redefine_release_with_macro(macro)
-        assert 'Release: %{release_str}' in spec_object.spec_content.sections['%package']
+        assert 'Release: %{release_str}' in spec_object.spec_content.section('%package')
 
     def test_get_extra_version_not_set(self, spec_object):
         assert spec_object.get_extra_version() == ''
@@ -240,17 +240,17 @@ class TestSpecFile(object):
         assert spec_object.get_extra_version() == 'rc1'
 
     def test_update_setup_dirname(self, spec_object):
-        prep = spec_object.spec_content.sections['%prep']
+        prep = spec_object.spec_content.section('%prep')
         spec_object.update_setup_dirname('test-1.0.2')
-        assert spec_object.spec_content.sections['%prep'] == prep
+        assert spec_object.spec_content.section('%prep') == prep
 
         spec_object.update_setup_dirname('test-1.0.2rc1')
-        prep = spec_object.spec_content.sections['%prep']
+        prep = spec_object.spec_content.section('%prep')
         setup = [l for l in prep if l.startswith('%setup')][0]
         assert '-n %{name}-%{REBASE_VER}' in setup
 
         spec_object.update_setup_dirname('test-1.0.2-rc1')
-        prep = spec_object.spec_content.sections['%prep']
+        prep = spec_object.spec_content.section('%prep')
         setup = [l for l in prep if l.startswith('%setup')][0]
         assert '-n %{name}-%{version}-%{REBASE_EXTRA_VER}' in setup
 
@@ -261,11 +261,9 @@ class TestSpecFile(object):
         assert target == 'test-1.0.2/misc'
 
     def test_typo_fix_spec_hook(self, spec_object):
-        assert '- This is chnagelog entry with some indentional typos' in spec_object.spec_content.sections[
-            '%changelog']
+        assert '- This is chnagelog entry with some indentional typos' in spec_object.spec_content.section('%changelog')
         TypoFixHook.run(spec_object, spec_object)
-        assert '- This is changelog entry with some intentional typos' in spec_object.spec_content.sections[
-            '%changelog']
+        assert '- This is changelog entry with some intentional typos' in spec_object.spec_content.section('%changelog')
 
     def test_paths_to_rpm_macros_spec_hook(self, spec_object):
         files = [
@@ -282,12 +280,12 @@ class TestSpecFile(object):
             '',
         ]
         PathsToRPMMacrosHook.run(spec_object, spec_object)
-        assert files == spec_object.spec_content.sections['%files']
-        assert files_devel == spec_object.spec_content.sections['%files devel']
+        assert files == spec_object.spec_content.section('%files')
+        assert files_devel == spec_object.spec_content.section('%files devel')
 
     def test_escape_macros_spec_hook(self, spec_object):
         EscapeMacrosHook.run(spec_object, spec_object)
-        assert spec_object.spec_content.sections['%build'][0] == "autoreconf -vi # Unescaped macros %%name %%{name}"
+        assert spec_object.spec_content.section('%build')[0] == "autoreconf -vi # Unescaped macros %%name %%{name}"
 
     def test_pypi_to_python_hosted_url_trans(self, spec_object):
         # pylint: disable=protected-access
@@ -300,12 +298,12 @@ class TestSpecFile(object):
         Check updated paths to patches in the rebased directory
         :return:
         """
-        line = [l for l in spec_object.spec_content.sections['%package'] if l.startswith('Patch5')][0]
+        line = [l for l in spec_object.spec_content.section('%package') if l.startswith('Patch5')][0]
         assert 'rebased-sources' in line
 
         spec_object.update_paths_to_patches()
 
-        line = [l for l in spec_object.spec_content.sections['%package'] if l.startswith('Patch5')][0]
+        line = [l for l in spec_object.spec_content.section('%package') if l.startswith('Patch5')][0]
         assert 'rebased-sources' not in line
 
     @pytest.mark.parametrize('preserve_macros', [
@@ -391,4 +389,4 @@ class TestSpecFile(object):
     def test_set_tag(self, spec_object, preserve_macros, tag, value, lines, lines_preserve):
         spec_object.set_tag(tag, value, preserve_macros=preserve_macros)
         for line in lines_preserve if preserve_macros else lines:
-            assert line in spec_object.spec_content.sections['%package']
+            assert line in spec_object.spec_content.section('%package')


### PR DESCRIPTION
Sections in a spec file can be enclosed in conditions, which means they can be duplicate.
Use list of tuples instead of dict to store them.