### PR TITLE
Properly handle text data from rpm module

### DIFF
--- a/rebasehelper/helpers/rpm_helper.py
+++ b/rebasehelper/helpers/rpm_helper.py
@@ -112,8 +112,8 @@ class RpmHelper(object):
         with open(rpm_name, "r") as f:
             return ts.hdrFromFdno(f)
 
-    @staticmethod
-    def get_info_from_rpm(rpm_name, info):
+    @classmethod
+    def get_info_from_rpm(cls, rpm_name, info):
         """Gets package name from an RPM file.
 
         Args:
@@ -125,9 +125,8 @@ class RpmHelper(object):
 
         :return:
         """
-        h = RpmHelper.get_header_from_rpm(rpm_name)
-        name = h[info].decode(DEFENC) if six.PY3 else h[info]
-        return name
+        h = cls.get_header_from_rpm(rpm_name)
+        return cls.decode(h[info])
 
     @staticmethod
     def get_arches():
@@ -180,3 +179,9 @@ class RpmHelper(object):
                     if line:
                         logger.verbose('rpm: %s', line)
                 return result
+
+    @classmethod
+    def decode(cls, data):
+        if six.PY3 and isinstance(data, bytes):
+            return data.decode(DEFENC)
+        return data

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -39,8 +39,8 @@ from operator import itemgetter
 
 from six.moves import urllib
 
-from rebasehelper.logger import logger
 from rebasehelper import constants
+from rebasehelper.logger import logger
 from rebasehelper.plugins import Plugin, PluginLoader
 from rebasehelper.archive import Archive
 from rebasehelper.exceptions import RebaseHelperError, DownloadError, ParseError, LookasideCacheError
@@ -277,16 +277,12 @@ class SpecFile(object):
         :return:
         """
         def guess_category():
-            def _decode(s):
-                if six.PY3:
-                    return s.decode(constants.DEFENC)
-                return s
             for pkg in self.spc.packages:
                 for category, regexp in six.iteritems(constants.PACKAGE_CATEGORIES):
-                    if regexp.match(_decode(pkg.header[rpm.RPMTAG_NAME])):
+                    if regexp.match(RpmHelper.decode(pkg.header[rpm.RPMTAG_NAME])):
                         return category
                     for provide in pkg.header[rpm.RPMTAG_PROVIDENAME]:
-                        if regexp.match(_decode(provide)):
+                        if regexp.match(RpmHelper.decode(provide)):
                             return category
             return None
 
@@ -599,7 +595,7 @@ class SpecFile(object):
 
         :return:
         """
-        return self.hdr[rpm.RPMTAG_RELEASE].decode(constants.DEFENC) if six.PY3 else self.hdr[rpm.RPMTAG_RELEASE]
+        return RpmHelper.decode(self.hdr[rpm.RPMTAG_RELEASE])
 
     def get_release_number(self):
         """
@@ -619,7 +615,7 @@ class SpecFile(object):
 
         :return:
         """
-        return self.hdr[rpm.RPMTAG_VERSION].decode(constants.DEFENC) if six.PY3 else self.hdr[rpm.RPMTAG_VERSION]
+        return RpmHelper.decode(self.hdr[rpm.RPMTAG_VERSION])
 
     def get_extra_version(self):
         """
@@ -1301,7 +1297,7 @@ class SpecFile(object):
 
         :return:
         """
-        return self.hdr[rpm.RPMTAG_NAME].decode(constants.DEFENC) if six.PY3 else self.hdr[rpm.RPMTAG_NAME]
+        return RpmHelper.decode(self.hdr[rpm.RPMTAG_NAME])
 
     def get_requires(self):
         """
@@ -1309,7 +1305,7 @@ class SpecFile(object):
 
         :return:
         """
-        return [r.decode(constants.DEFENC) if six.PY3 else r for r in self.hdr[rpm.RPMTAG_REQUIRES]]
+        return [RpmHelper.decode(r) for r in self.hdr[rpm.RPMTAG_REQUIRES]]
 
     def update_changelog(self, changelog_entry):
         """Inserts a new entry into the changelog and saves the SpecFile.


### PR DESCRIPTION
Future rpm versions will return unicode instead of bytes in python 3.
Account for that in a new wrapper method.