### PR TITLE
Remove 'download' argument from SpecFile's constructor

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -187,9 +187,7 @@ class Application(object):
         """
         self.rebase_spec_file_path = get_rebase_name(self.rebased_sources_dir, self.spec_file_path)
 
-        self.spec_file = SpecFile(self.spec_file_path,
-                                  self.execution_dir,
-                                  download=not self.conf.not_download_sources)
+        self.spec_file = SpecFile(self.spec_file_path, self.execution_dir)
         # Check whether test suite is enabled at build time
         if not self.spec_file.is_test_suite_enabled():
             results_store.set_info_text('WARNING', 'Test suite is not enabled at build time.')
@@ -233,8 +231,8 @@ class Application(object):
         spec_hooks_runner.run_spec_hooks(self.spec_file, self.rebase_spec_file, **self.kwargs)
 
         # spec file object has been sanitized downloading can proceed
-        for spec_file in [self.spec_file, self.rebase_spec_file]:
-            if spec_file.download:
+        if not self.conf.not_download_sources:
+            for spec_file in [self.spec_file, self.rebase_spec_file]:
                 spec_file.download_remote_sources()
                 # parse spec again with sources downloaded to properly expand %prep section
                 spec_file._update_data()  # pylint: disable=protected-access

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -233,9 +233,8 @@ class SpecFile(object):
     prep_section = []
     removed_patches = []
 
-    def __init__(self, path, sources_location='', download=True):
+    def __init__(self, path, sources_location=''):
         self.path = path
-        self.download = download
         self.sources_location = sources_location
         #  Read the content of the whole SPEC file
         self._read_spec_content()
@@ -1251,7 +1250,7 @@ class SpecFile(object):
 
         """
         shutil.copy(self.path, new_path)
-        new_object = SpecFile(new_path, self.sources_location, self.download)
+        new_object = SpecFile(new_path, self.sources_location)
         return new_object
 
     def save(self):

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -73,7 +73,7 @@ class TestSpecFile(object):
 
     @pytest.fixture
     def spec_object(self, workdir):
-        sf = SpecFile(self.SPEC_FILE, workdir, download=False)
+        sf = SpecFile(self.SPEC_FILE, workdir)
         return sf
 
     def test_get_release(self, spec_object):


### PR DESCRIPTION
Only Application makes use of this argument. The value can be accessed
from configuration taken from CLI/config file.