### PR TITLE
Fix capturing rpm output and include it in exception

### DIFF
--- a/rebasehelper/exceptions.py
+++ b/rebasehelper/exceptions.py
@@ -39,6 +39,9 @@ class RebaseHelperError(Exception):
             self.msg = args[0]
         self.logfiles = kwargs.get('logfiles')
 
+    def __str__(self):
+        return str(self.msg) if self.msg else ''
+
 
 class CheckerNotFoundError(RuntimeError):
     """Error indicating failure unable to find checker binary"""

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -298,12 +298,9 @@ class SpecFile(object):
         # load rpm information
         try:
             self.spc = RpmHelper.parse_spec(self.path, flags=rpm.RPMSPEC_ANYARCH)
-        except ValueError:
-            try:
-                # try again with RPMSPEC_FORCE flag (the default)
-                self.spc = RpmHelper.parse_spec(self.path)
-            except ValueError:
-                raise RebaseHelperError("Problem with parsing SPEC file '%s'" % self.path)
+        except RebaseHelperError:
+            # try again with RPMSPEC_FORCE flag (the default)
+            self.spc = RpmHelper.parse_spec(self.path)
         self.category = guess_category()
         self.sources = self._get_spec_sources_list(self.spc)
         self.prep_section = self.spc.prep


### PR DESCRIPTION
Parsing errors from rpm were supposed to be logged, but that didn't happen in case of exception handling (so basically never).
Fix that and instead of logging the errors using logger, include them in the raised exception instance to make it more convenient.