### PR TITLE
packit.yaml: drop unused content

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -2,15 +2,5 @@ specfile_path: rebase-helper.spec
 synced_files:
     - .packit.yml
     - rebase-helper.spec
-jobs:
-    - trigger: release
-      release_to:
-          - master
-    - trigger: pull_request
-      release_to:
-          - master
 upstream_project_name: rebase-helper
 downstream_package_name: rebase-helper
-checks:
-    - name: simple-koji-ci
-    - name: Fedora CI


### PR DESCRIPTION
We are working on a next release of packit where we'll finally implement jobs.
Our current plan is to change the schema, which means that future version of
packit would fail parsing this config file.

This PR therefore removes content from packit.yml which packit does not even
process now.