### PR TITLE
Fix ansicolors dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ def get_requirements():
         'requests',
         'six',
         'GitPython',
-        'ansicolors',
+        # https://github.com/jonathaneunice/colors/pull/1
+        'ansicolors@git+https://github.com/FrNecas/colors.git@frnecas-bright-colors',
     ]
     # there is no rpm nor gssapi inside RTD build environment
     if not os.getenv('READTHEDOCS'):
@@ -146,11 +147,6 @@ setup(
     },
     install_requires=get_requirements(),
     setup_requires=[],
-    # this is only a temporary change until the PR adding bright colors support isn't merged to upstream
-    # link to the PR: https://github.com/jonathaneunice/colors/pull/1
-    dependency_links=[
-        'git+https://github.com/FrNecas/colors.git@#egg=ansicolors'
-    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Branch name was missing so the link could never work, as it defaults to **master**, which doesn't contain the change.

According to [PEP 508](https://www.python.org/dev/peps/pep-0508/), it is possible to specify an URL in `install_requires` directly, no need for `dependency_links`.