### PR TITLE
Fix printing of checker output for unsupported tools

### DIFF
--- a/rebasehelper/plugins/output_tools/__init__.py
+++ b/rebasehelper/plugins/output_tools/__init__.py
@@ -95,11 +95,12 @@ class BaseOutputTool(Plugin):
         """Iterates over all checkers output to highlight important checkers warning"""
         checkers_results = results_store.get_checkers()
         for check_tool in cls.manager.checkers.plugins.values():
-            for check, data in sorted(checkers_results.items()):
-                if check == check_tool.name:
-                    out = check_tool.get_important_changes(data)
-                    if out:
-                        logger_output.warning('\n'.join(out))
+            if check_tool:
+                for check, data in sorted(checkers_results.items()):
+                    if check == check_tool.name:
+                        out = check_tool.get_important_changes(data)
+                        if out:
+                            logger_output.warning('\n'.join(out))
 
     @classmethod
     def print_report_file_path(cls):

--- a/rebasehelper/plugins/output_tools/text.py
+++ b/rebasehelper/plugins/output_tools/text.py
@@ -165,9 +165,10 @@ class Text(BaseOutputTool):
     def print_checkers_text_output(cls, checkers_results):
         """Function prints text output for every checker"""
         for check_tool in cls.manager.checkers.plugins.values():
-            for check, data in sorted(checkers_results.items()):
-                if check == check_tool.name:
-                    logger_report.info('\n'.join(check_tool.format(data)))
+            if check_tool:
+                for check, data in sorted(checkers_results.items()):
+                    if check == check_tool.name:
+                        logger_report.info('\n'.join(check_tool.format(data)))
 
     @classmethod
     def print_build_log_hooks_result(cls, build_log_hooks_result):


### PR DESCRIPTION
If a checker is not supported, `check_tool` is set to  None and it results
in AttributeError.