### PR TITLE
Use rpm.reloadConfig() before parsing SPEC

### DIFF
--- a/rebasehelper/helpers/macro_helper.py
+++ b/rebasehelper/helpers/macro_helper.py
@@ -61,8 +61,14 @@ class MacroHelper:
         except rpm.error:
             return default
 
-    @staticmethod
-    def expand_macros(macros):
+    @classmethod
+    def purge_macro(cls, macro: str) -> None:
+        m = '%{{{}}}'.format(macro)
+        while cls.expand(m, m) != m:
+            rpm.delMacro(macro)
+
+    @classmethod
+    def expand_macros(cls, macros):
         """Expands values of multiple macros.
 
         Args:
@@ -74,7 +80,7 @@ class MacroHelper:
 
         """
         for macro in macros:
-            macro['value'] = MacroHelper.expand(macro['value'])
+            macro['value'] = cls.expand(macro['value'])
         return macros
 
     @staticmethod

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -322,14 +322,11 @@ class SpecFile:
                         if category.value.match(RpmHelper.decode(provide)):
                             return category
             return None
-
-        def replace_macro(macro, value):
-            m = '%{{{}}}'.format(macro)
-            while MacroHelper.expand(m, m) != m:
-                rpm.delMacro(macro)
-            rpm.addMacro(macro, value)
+        # reset all macros and settings
+        rpm.reloadConfig()
         # ensure that %{_sourcedir} macro is set to proper location
-        replace_macro('_sourcedir', self.sources_location)
+        MacroHelper.purge_macro('_sourcedir')
+        rpm.addMacro('_sourcedir', self.sources_location)
         # explicitly discard old instance to prevent rpm from destroying
         # "sources" and "patches" lua tables after new instance is created
         self.spc = None
@@ -981,9 +978,7 @@ class SpecFile:
             macros = {m for m, _ in _find_macros(s)}
             macros.update(m for m, _ in _find_macros(_expand_macros(s)))
             for macro in macros:
-                m = '%{{{}}}'.format(macro)
-                while MacroHelper.expand(m, m) != m:
-                    rpm.delMacro(macro)
+                MacroHelper.purge_macro(macro)
                 value = _get_macro_value(macro)
                 if value and MacroHelper.expand(value):
                     rpm.addMacro(macro, value)

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -231,6 +231,8 @@ class TestSpecFile:
         assert spec_object.get_extra_version() == 'rc1'
 
     def test_update_setup_dirname(self, spec_object):
+        spec_object.set_extra_version('rc1')
+
         prep = spec_object.spec_content.section('%prep')
         spec_object.update_setup_dirname('test-1.0.2')
         assert spec_object.spec_content.section('%prep') == prep


### PR DESCRIPTION
`rpm.reloadConfig()`, among other things, resets all macros to default values and removes previously defined macros. That should prevent issues with polluted global macro namespace when parsing multiple different SPEC files.