### PR TITLE
Prevent mock (userhelper) from asking for a password

### DIFF
--- a/rebasehelper/plugins/build_tools/__init__.py
+++ b/rebasehelper/plugins/build_tools/__init__.py
@@ -25,9 +25,16 @@
 import os
 import shutil
 
+import pam  # type: ignore
+
 from rebasehelper.helpers.path_helper import PathHelper
 from rebasehelper.temporary_environment import TemporaryEnvironment
 from rebasehelper.logger import logger
+
+
+def check_mock_privileges() -> bool:
+    # try to authenticate as superuser using mock PAM service
+    return pam.pam().authenticate('root', '', service='mock')
 
 
 class BuildTemporaryEnvironment(TemporaryEnvironment):

--- a/rebasehelper/plugins/build_tools/rpm/mock.py
+++ b/rebasehelper/plugins/build_tools/rpm/mock.py
@@ -29,7 +29,7 @@ from typing import List
 from rebasehelper.helpers.process_helper import ProcessHelper
 from rebasehelper.logger import logger
 from rebasehelper.helpers.path_helper import PathHelper
-from rebasehelper.plugins.build_tools import MockTemporaryEnvironment
+from rebasehelper.plugins.build_tools import MockTemporaryEnvironment, check_mock_privileges
 from rebasehelper.plugins.build_tools.rpm import BuildToolBase
 from rebasehelper.exceptions import BinaryPackageBuildError
 
@@ -68,6 +68,9 @@ class Mock(BuildToolBase):  # pylint: disable=abstract-method
             cmd.extend(['--arch', arch])
         if builder_options is not None:
             cmd.extend(builder_options)
+
+        if not check_mock_privileges():
+            cmd = ['pkexec'] + cmd
 
         ret = ProcessHelper.run_subprocess(cmd, output_file=output)
 

--- a/rebasehelper/plugins/build_tools/srpm/mock.py
+++ b/rebasehelper/plugins/build_tools/srpm/mock.py
@@ -27,7 +27,7 @@ import os
 from typing import List
 
 from rebasehelper.logger import logger
-from rebasehelper.plugins.build_tools import MockTemporaryEnvironment
+from rebasehelper.plugins.build_tools import MockTemporaryEnvironment, check_mock_privileges
 from rebasehelper.plugins.build_tools.srpm import SRPMBuildToolBase
 from rebasehelper.exceptions import SourcePackageBuildError
 from rebasehelper.helpers.path_helper import PathHelper
@@ -64,6 +64,9 @@ class Mock(SRPMBuildToolBase):
         cmd.extend(['--spec', spec])
         cmd.extend(['--sources', path_to_sources])
         cmd.extend(['--resultdir', results_dir])
+
+        if not check_mock_privileges():
+            cmd = ['pkexec'] + cmd
 
         ret = ProcessHelper.run_subprocess_cwd_env(cmd,
                                                    cwd=spec_loc,

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ def get_requirements():
         'marshmallow<3.0.0',
         'copr',
         'pyquery',
+        'python-pam',
         'requests',
         'GitPython',
         # https://github.com/jonathaneunice/colors/pull/1


### PR DESCRIPTION
`mock` uses `userhelper` to get superuser permissions, but `userhelper` doesn't support non-interactive use.

Run `mock` using `pkexec` wrapper if (and only if) `userhelper` would need to ask for a password.

Fixes #636.