### PR TITLE
Use local builder when the build can't be downloaded from koji

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -541,7 +541,9 @@ class Application:
             logger.info('Building source package for %s version %s', package_name, package_version)
 
             if version == 'old' and self.conf.get_old_build_from_koji:
-                koji_build_id, package_version = KojiHelper.get_old_build_info(package_name, package_version)
+                koji_build_id, ver = KojiHelper.get_old_build_info(package_name, package_version)
+                if ver:
+                    package_version = ver
 
             build_dict = dict(
                 name=package_name,
@@ -602,7 +604,9 @@ class Application:
                 package_version = spec.get_version()
 
                 if version == 'old' and self.conf.get_old_build_from_koji:
-                    koji_build_id, package_version = KojiHelper.get_old_build_info(package_name, package_version)
+                    koji_build_id, ver = KojiHelper.get_old_build_info(package_name, package_version)
+                    if ver:
+                        package_version = ver
 
                 build_dict = dict(
                     name=package_name,

--- a/rebasehelper/helpers/koji_helper.py
+++ b/rebasehelper/helpers/koji_helper.py
@@ -385,16 +385,8 @@ class KojiHelper:
         if cls.functional:
             session = KojiHelper.create_session()
             koji_version, koji_build_id = KojiHelper.get_build(session, package_name, package_version)
-            if not koji_version:
-                # fallback to the latest Koji build
-                koji_version, koji_build_id = KojiHelper.get_latest_build(session, package_name)
             if koji_version:
-                if koji_version != package_version:
-                    logger.warning('Version of the latest Koji build (%s) with id (%s) '
-                                   'differs from version in SPEC file (%s)!',
-                                   koji_version, koji_build_id, package_version)
-                package_version = koji_version
-                return koji_build_id, package_version
+                return koji_build_id, koji_version
             else:
                 logger.warning('Unable to find old version Koji build!')
                 return None, None


### PR DESCRIPTION
In `golang-github-google-cmp` rebase from 0.2.0 to 0.3.0, the old build wasn't in koji, whereas the new one was. rebase-helper couldn't handle such thing. What we should also consider is changing `KojiHelper.get_old_build_info()`. Currently if the old version build can't be obtained, it fallbacks to getting the latest build. Since this method is used only when `--get-old-build-from-koji` is active, it imho doesn't make much sense (we want the old build or nothing, getting the info about new build is pointless). What's your opinion @nforro ? Is there any case, where the fallback could be useful?