### PR TITLE
 Move setup dependencies to setup_requires

### DIFF
--- a/docker/Dockerfile.webhooks
+++ b/docker/Dockerfile.webhooks
@@ -2,7 +2,7 @@ FROM python:3
 
 COPY docker/webhooks.py /webhooks.py
 
-RUN pip install --no-cache-dir GitPython six twine
+RUN pip install --no-cache-dir GitPython twine
 
 EXPOSE 80/TCP
 

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,6 @@ def get_requirements():
         'pyquery',
         'python-pam',
         'requests',
-        'setuptools_scm',
-        'setuptools_scm_git_archive',
         'GitPython',
     ]
     # there is no rpm nor gssapi inside RTD build environment
@@ -153,7 +151,10 @@ setup(
         ]
     },
     install_requires=get_requirements(),
-    setup_requires=[],
+    setup_requires=[
+        'setuptools_scm',
+        'setuptools_scm_git_archive',
+    ],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
`setuptools_scm` and `setuptools_scm_git_archive` are required for `setup.py` to run, so they need to be listed in `setup_requires`, not `install_requires`.