### PR TITLE
Disable stdout/stderr buffering in release webhook

### DIFF
--- a/docker/Dockerfile.webhooks
+++ b/docker/Dockerfile.webhooks
@@ -6,4 +6,4 @@ RUN pip install --no-cache-dir GitPython twine
 
 EXPOSE 80/TCP
 
-CMD ["python", "/webhooks.py"]
+CMD ["python", "-u", "/webhooks.py"]


### PR DESCRIPTION
I hope this will prevent the incomplete output issue.