### PR TITLE
Remove automatically created logging file handlers

### DIFF
--- a/docs/user_guide/logging.rst
+++ b/docs/user_guide/logging.rst
@@ -14,14 +14,20 @@ Logger name                     Purpose
 =============================== =============================================================================
 
 
-:program:`rebase-helper` uses :class:`rebasehelper.logger.CustomLogger` logger class which provides extra
-logging levels.
+:program:`rebase-helper` uses :class:`rebasehelper.logger.CustomLogger` logger class which provides
+extra logging levels.
 
-:mod:`rebasehelper.logger` module provides two utility functions to setup default handlers.
-:meth:`rebasehelper.logger.create_stream_handlers` sets up the default console handlers for
-:samp:`rebasehelper` and :samp:`rebasehelper.summary` loggers.
-:meth:`rebasehelper.logger.create_file_handlers` sets up the default file handlers for :samp:`rebasehelper` logger,
-with INFO, VERBOSE and DEBUG levels. The respective log files are located in :file:`rebase-helper-results/logs/`.
+:class:`rebasehelper.logger.LoggerHelper` class provides 3 utility methods to manage default handlers:
+
+* :meth:`rebasehelper.logger.LoggerHelper.create_stream_handlers` sets up the default console handlers
+  for :samp:`rebasehelper` and :samp:`rebasehelper.summary` loggers.
+
+* :meth:`rebasehelper.logger.LoggerHelper.create_file_handlers` sets up the default file handlers
+  for :samp:`rebasehelper` logger, with INFO, VERBOSE and DEBUG levels.
+  The respective log files are located in :file:`rebase-helper-results/logs/`.
+
+* :meth:`rebasehelper.logger.LoggerHelper.remove_file_handlers` removes specified file handlers
+  from :samp:`rebasehelper` logger.
 
 
 Examples
@@ -45,16 +51,17 @@ Examples
 
     # run a complete rebase with default log handlers
 
-    from rebasehelper.logger import create_stream_handlers
+    from rebasehelper.logger import LoggerHelper
     from rebasehelper.config import Config
     from rebasehelper.cli import CLI
     from rebasehelper.application import Application
 
-    create_stream_handlers()
+    LoggerHelper.create_stream_handlers()
     config = Config()
     cli = CLI()
     config.merge(cli)
-    # create_file_handlers() is called in Application.setup()
     exec_dir, res_dir = Application.setup(config)
+    # default file handlers are automatically created and removed by Application instance,
+    # unless disabled by passing create_logs=False
     app = Application(config, exec_dir, res_dir)
     app.run()

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -32,7 +32,7 @@ from rebasehelper import VERSION
 from rebasehelper.options import OPTIONS, traverse_options
 from rebasehelper.constants import PROGRAM_DESCRIPTION, NEW_ISSUE_LINK, LOGS_DIR, TRACEBACK_LOG, DEBUG_LOG
 from rebasehelper.application import Application
-from rebasehelper.logger import create_stream_handlers, CustomLogger, LoggerHelper
+from rebasehelper.logger import CustomLogger, LoggerHelper
 from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.helpers.console_helper import ConsoleHelper
 from rebasehelper.config import Config
@@ -106,7 +106,7 @@ class CliHelper:
     def run():
         results_dir = None
         try:
-            main_handler, output_tool_handler = create_stream_handlers()
+            main_handler, output_tool_handler = LoggerHelper.create_stream_handlers()
             cli = CLI()
             if hasattr(cli, 'version'):
                 print(VERSION)
@@ -116,15 +116,14 @@ class CliHelper:
             config.merge(cli)
             for handler in [main_handler, output_tool_handler]:
                 handler.set_terminal_background(config.background)
-
-            ConsoleHelper.use_colors = ConsoleHelper.should_use_colors(config)
-            execution_dir, results_dir = Application.setup(config)
             if config.verbose == 0:
                 main_handler.setLevel(logging.INFO)
             elif config.verbose == 1:
                 main_handler.setLevel(CustomLogger.VERBOSE)
             else:
                 main_handler.setLevel(logging.DEBUG)
+            ConsoleHelper.use_colors = ConsoleHelper.should_use_colors(config)
+            execution_dir, results_dir = Application.setup(config)
             app = Application(config, execution_dir, results_dir)
             app.run()
         except KeyboardInterrupt:


### PR DESCRIPTION
Fixes #684.

I decided not to implement `cleanup()` method, because it is necessary to remember the created handler instances, and since their lifetime matches the lifetime of `Application` instance, creating them in its constructor and removing them in its destructor makes more sense.