### PR TITLE
Add .eggs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 dist
 build
 eggs
+.eggs
 parts
 bin
 var


### PR DESCRIPTION
After installing setuptools-scm using pip,  `.eggs` directory appeared in the root of my git repo.