### PR TITLE
Always log the reason of build failure

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -562,7 +562,6 @@ class Application:
                 else:
                     msg = 'Building {} SRPM packages failed; see logs in {} for more information'.format(
                         version, os.path.join(results_dir, 'SRPM'))
-                logger.error(msg)
                 raise RebaseHelperError(msg, logfiles=builder.get_logs().get('logs'))
             except Exception:
                 raise RebaseHelperError('Building package failed with unknown reason. '
@@ -647,7 +646,6 @@ class Application:
                 else:
                     msg = 'Building {} RPM packages failed; see {} for more information'.format(version, e.logfile)
 
-                logger.error(msg)
                 raise RebaseHelperError(msg, logfiles=builder.get_logs().get('logs'))
             except Exception:
                 raise RebaseHelperError('Building package failed with unknown reason. '
@@ -821,6 +819,7 @@ class Application:
                         self.run_package_checkers(self.results_dir, category=CheckerCategory.RPM)
                     # Print summary and return error
                     except RebaseHelperError as e:
+                        logger.error(e.msg)
                         if self.prepare_next_run(self.results_dir):
                             continue
                         self.print_summary(e)


### PR DESCRIPTION
Building could fail due to other reasons than just rpmbuild/mock failure.
Copr config could be missing or Koji authentication can fail. Inform the
user even in such cases about what went wrong.