### PR TITLE
Use RpmHeader helper class to access package header attributes

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -112,7 +112,7 @@ class Application:
                 sources = [os.path.basename(s) for s in self.spec_file.sources]
                 rebased_sources = [os.path.basename(s) for s in self.rebase_spec_file.sources]
                 uploaded = LookasideCacheHelper.update_sources('fedpkg', self.rebased_sources_dir,
-                                                               self.rebase_spec_file.get_package_name(),
+                                                               self.rebase_spec_file.header.name,
                                                                sources, rebased_sources,
                                                                upload=not self.conf.skip_upload)
                 self._update_gitignore(uploaded, self.rebased_sources_dir)
@@ -148,7 +148,7 @@ class Application:
 
         if not self.conf.sources:
             self.conf.sources = plugin_manager.versioneers.run(self.conf.versioneer,
-                                                               self.spec_file.get_package_name(),
+                                                               self.spec_file.header.name,
                                                                self.spec_file.category,
                                                                self.conf.versioneer_blacklist)
             if self.conf.sources:
@@ -173,8 +173,8 @@ class Application:
             self.rebase_spec_file.extra_version_separator = separator
             self.rebase_spec_file.set_extra_version(extra_version)
 
-        if not self.conf.skip_version_check and parse_version(self.rebase_spec_file.get_version()) \
-                <= parse_version(self.spec_file.get_version()):
+        if not self.conf.skip_version_check and parse_version(self.rebase_spec_file.header.version) \
+                <= parse_version(self.spec_file.header.version):
             raise RebaseHelperError("Current version is equal to or newer than the requested version, nothing to do.")
 
         self.rebase_spec_file.update_changelog(self.conf.changelog_entry)
@@ -483,8 +483,8 @@ class Application:
             koji_build_id = None
             results_dir = '{}-build'.format(os.path.join(self.results_dir, version))
             spec = self.spec_file if version == 'old' else self.rebase_spec_file
-            package_name = spec.get_package_name()
-            package_version = spec.get_version()
+            package_name = spec.header.name
+            package_version = spec.header.version
             logger.info('Building source package for %s version %s', package_name, package_version)
 
             if version == 'old' and self.conf.get_old_build_from_koji:
@@ -546,8 +546,8 @@ class Application:
 
             if self.conf.build_tasks is None:
                 spec = self.spec_file if version == 'old' else self.rebase_spec_file
-                package_name = spec.get_package_name()
-                package_version = spec.get_version()
+                package_name = spec.header.name
+                package_version = spec.header.version
 
                 if version == 'old' and self.conf.get_old_build_from_koji:
                     koji_build_id, ver = KojiHelper.get_old_build_info(package_name, package_version)
@@ -664,8 +664,8 @@ class Application:
             results_store.set_result_message('fail', exception.msg)
         else:
             result = "Rebase from {}-{} to {}-{} completed without an error".format(
-                self.spec_file.get_package_name(), self.spec_file.get_version(),
-                self.rebase_spec_file.get_package_name(), self.rebase_spec_file.get_version())
+                self.spec_file.header.name, self.spec_file.header.version,
+                self.rebase_spec_file.header.name, self.rebase_spec_file.header.version)
             results_store.set_result_message('success', result)
 
         if self.rebase_spec_file:

--- a/rebasehelper/plugins/build_tools/rpm/rpmbuild.py
+++ b/rebasehelper/plugins/build_tools/rpm/rpmbuild.py
@@ -89,8 +89,7 @@ class Rpmbuild(BuildToolBase):  # pylint: disable=abstract-method
 
         :param spec: SpecFile object
         """
-        req_pkgs = spec.get_requires()
-        if not RpmHelper.all_packages_installed(req_pkgs):
+        if not RpmHelper.all_packages_installed(spec.header.requires):
             question = '\nSome build dependencies are missing. Do you want to install them now'
             if conf.non_interactive or InputHelper.get_message(question):
                 if RpmHelper.install_build_dependencies(spec.path, assume_yes=conf.non_interactive) != 0:

--- a/rebasehelper/plugins/checkers/abipkgdiff.py
+++ b/rebasehelper/plugins/checkers/abipkgdiff.py
@@ -27,8 +27,6 @@ import os
 import re
 from typing import Optional, cast
 
-import rpm  # type: ignore
-
 from rebasehelper.exceptions import RebaseHelperError, CheckerNotFoundError
 from rebasehelper.logger import CustomLogger
 from rebasehelper.results_store import results_store
@@ -85,7 +83,7 @@ class AbiPkgDiff(BaseChecker):
         find = [x for x in debug if RpmHelper.split_nevra(os.path.basename(x))['name'] == debuginfo]
         if find:
             return find[0]
-        srpm = RpmHelper.get_info_from_rpm(pkg, rpm.RPMTAG_SOURCERPM)
+        srpm = RpmHelper.get_header_from_rpm(pkg).sourcerpm
         debuginfo = '{}-debuginfo'.format(RpmHelper.split_nevra(srpm)['name'])
         find = [x for x in debug if RpmHelper.split_nevra(os.path.basename(x))['name'] == debuginfo]
         if find:

--- a/rebasehelper/plugins/checkers/pkgdiff.py
+++ b/rebasehelper/plugins/checkers/pkgdiff.py
@@ -63,7 +63,7 @@ class PkgDiff(BaseChecker):
         if packages is None:
             return None
         basic_package = sorted(packages)[0]
-        return RpmHelper.get_info_from_rpm(basic_package, name)
+        return getattr(RpmHelper.get_header_from_rpm(basic_package), name)
 
     @classmethod
     def _create_xml(cls, name, input_structure):

--- a/rebasehelper/plugins/checkers/rpmdiff.py
+++ b/rebasehelper/plugins/checkers/rpmdiff.py
@@ -59,7 +59,7 @@ class RpmDiff(BaseChecker):
     def _get_rpms(cls, rpm_list):
         rpm_dict = {}
         for rpm_name in rpm_list:
-            rpm_dict[RpmHelper.get_info_from_rpm(rpm_name, 'name')] = rpm_name
+            rpm_dict[RpmHelper.get_header_from_rpm(rpm_name).name] = rpm_name
         return rpm_dict
 
     @classmethod

--- a/rebasehelper/plugins/spec_hooks/commit_hash_updater.py
+++ b/rebasehelper/plugins/spec_hooks/commit_hash_updater.py
@@ -59,7 +59,7 @@ class CommitHashUpdater(BaseSpecHook):
                 logger.warning("Rate limit exceeded on Github API! Try again later.")
             return None
         data = r.json()
-        version = spec_file.get_version()
+        version = spec_file.header.version
         tag_name = None
         for release in data:
             if version in release.get('name'):

--- a/rebasehelper/plugins/spec_hooks/replace_old_version.py
+++ b/rebasehelper/plugins/spec_hooks/replace_old_version.py
@@ -93,8 +93,8 @@ class ReplaceOldVersion(BaseSpecHook):
 
     @classmethod
     def run(cls, spec_file: SpecFile, rebase_spec_file: SpecFile, **kwargs: Any):
-        old_version = spec_file.get_version()
-        new_version = rebase_spec_file.get_version()
+        old_version = spec_file.header.version
+        new_version = rebase_spec_file.header.version
         replace_with_macro = bool(kwargs.get('replace_old_version_with_macro'))
 
         subversion_patterns = cls._create_possible_replacements(old_version, new_version, replace_with_macro)

--- a/rebasehelper/plugins/spec_hooks/ruby_helper.py
+++ b/rebasehelper/plugins/spec_hooks/ruby_helper.py
@@ -103,7 +103,7 @@ class RubyHelper(BaseSpecHook):
             # update data so that RPM macros are populated correctly
             rebase_spec_file._update_data()  # pylint: disable=protected-access
             instructions = cls._get_instructions(comments,
-                                                 spec_file.get_version(),
-                                                 rebase_spec_file.get_version())
+                                                 spec_file.header.version,
+                                                 rebase_spec_file.header.version)
             logfile = os.path.join(kwargs['workspace_dir'], '{}.log'.format(source))
             cls._build_source_from_instructions(instructions, source, logfile)

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -107,11 +107,6 @@ class TestSpecFile:
         PATCH_4,
     ]
 
-    def test_get_release(self, spec_object):
-        match = re.search(r'([0-9.]*[0-9]+)\w*', spec_object.get_release())
-        assert match is not None
-        assert match.group(1) == spec_object.get_release_number()
-
     def test_get_release_number(self, spec_object):
         assert spec_object.get_release_number() == '34'
 
@@ -121,24 +116,18 @@ class TestSpecFile:
         spec_object.set_release_number(22)
         assert spec_object.get_release_number() == '22'
 
-    def test_get_version(self, spec_object):
-        assert spec_object.get_version() == self.VERSION
-
     def test_set_version(self, spec_object):
         NEW_VERSION = '1.2.3.4.5'
         spec_object.set_version(NEW_VERSION)
         spec_object.save()
-        assert spec_object.get_version() == NEW_VERSION
+        assert spec_object.header.version == NEW_VERSION
 
     def test_set_version_using_archive(self, spec_object):
         NEW_VERSION = '1.2.3.4.5'
         ARCHIVE_NAME = 'test-{0}.tar.xz'.format(NEW_VERSION)
         spec_object.set_version_using_archive(ARCHIVE_NAME)
         spec_object.save()
-        assert spec_object.get_version() == NEW_VERSION
-
-    def test_get_package_name(self, spec_object):
-        assert spec_object.get_package_name() == self.NAME
+        assert spec_object.header.version == NEW_VERSION
 
     def test__write_spec_content(self, spec_object):
         # pylint: disable=protected-access
@@ -178,7 +167,7 @@ class TestSpecFile:
 
     def test_get_requires(self, spec_object):
         expected = {'openssl-devel', 'pkgconfig', 'texinfo', 'gettext', 'autoconf'}
-        req = spec_object.get_requires()
+        req = spec_object.header.requires
         assert len(expected.intersection(req)) == len(expected)
 
     def test_split_version_string(self):
@@ -240,7 +229,7 @@ class TestSpecFile:
         # the release number was changed
         assert spec_object.get_release_number() == '0.1'
         # the release string now contains the extra version
-        match = re.search(r'([0-9.]*[0-9]+)\.b1\w*', spec_object.get_release())
+        match = re.search(r'([0-9.]*[0-9]+)\.b1\w*', spec_object.header.release)
         assert match is not None
         assert match.group(1) == spec_object.get_release_number()
 


### PR DESCRIPTION
I decided to keep `SpecFile.get_version()` in order not to break `packit`.