### PR TITLE
Refactor SpecFile._update_data()

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -187,7 +187,7 @@ class Application:
             for spec_file in [self.spec_file, self.rebase_spec_file]:
                 spec_file.download_remote_sources()
                 # parse spec again with sources downloaded to properly expand %prep section
-                spec_file._update_data()  # pylint: disable=protected-access
+                spec_file.update()
 
     def _initialize_data(self):
         """Function fill dictionary with default data"""
@@ -401,7 +401,7 @@ class Application:
 
         # Generate patch
         self.rebased_repo.git.add(all=True)
-        self.rebase_spec_file._update_data()  # pylint: disable=protected-access
+        self.rebase_spec_file.update()
         self.rebased_repo.index.commit(MacroHelper.expand(self.conf.changelog_entry, self.conf.changelog_entry))
         patch = self.rebased_repo.git.format_patch('-1', stdout=True, stdout_as_string=False)
         with open(os.path.join(self.results_dir, 'changes.patch'), 'wb') as f:

--- a/rebasehelper/helpers/rpm_helper.py
+++ b/rebasehelper/helpers/rpm_helper.py
@@ -188,7 +188,12 @@ class RpmHelper:
                 return result
 
     @classmethod
-    def get_rpm_spec(cls, path) -> rpm.spec:
+    def get_rpm_spec(cls, path: str, sourcedir: str) -> rpm.spec:
+        # reset all macros and settings
+        rpm.reloadConfig()
+        # ensure that %{_sourcedir} macro is set to proper location
+        MacroHelper.purge_macro('_sourcedir')
+        rpm.addMacro('_sourcedir', sourcedir)
         try:
             spec = cls.parse_spec(path, flags=rpm.RPMSPEC_ANYARCH)
         except RebaseHelperError:

--- a/rebasehelper/plugins/spec_hooks/ruby_helper.py
+++ b/rebasehelper/plugins/spec_hooks/ruby_helper.py
@@ -101,7 +101,7 @@ class RubyHelper(BaseSpecHook):
                 # nothing to do
                 continue
             # update data so that RPM macros are populated correctly
-            rebase_spec_file._update_data()  # pylint: disable=protected-access
+            rebase_spec_file.update()
             instructions = cls._get_instructions(comments,
                                                  spec_file.header.version,
                                                  rebase_spec_file.header.version)


### PR DESCRIPTION
Move spec-related stuff to `RpmHelper.get_rpm_spec()`, it doesn't work properly without it anyway.

Introduce public `SpecFile.update()` method and use it instead of `SpecFile._update_data()` everywhere except in `SpecFile` constructor.

Fixes #710.