### PR TITLE
Fix replacing tags while preserving macros

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -958,6 +958,8 @@ class SpecFile:
                         values[index] = newval[m.a:m.a+m.size]
                         if not values[index - 1]:
                             values[index - 1] = newval[i:m.a]
+                        else:
+                            values[index - 1] += newval[i:m.a]
                     else:
                         values[index] = newval[i:m.a+m.size]
                     i = m.a + m.size


### PR DESCRIPTION
Example case that doesn't work properly without this fix: `1%{?dist}` ⇒ `1.1%{?dist}`