### PR TITLE
patcher: check for merge conflicts in binary mode

### DIFF
--- a/rebasehelper/patcher.py
+++ b/rebasehelper/patcher.py
@@ -203,8 +203,8 @@ class Patcher:
                     # check for unresolved conflicts
                     unresolved = []
                     for file in unmerged:
-                        with open(os.path.join(cls.old_sources, file)) as f:
-                            if [l for l in f.readlines() if '<<<<<<<' in l]:
+                        with open(os.path.join(cls.old_sources, file), 'rb') as f:
+                            if [l for l in f if b'<<<<<<<' in l]:
                                 unresolved.append(file)
                     if unresolved:
                         if InputHelper.get_message('There are still unresolved conflicts. '


### PR DESCRIPTION
This should prevent rebase-helper dying on files which have non-utf8 characters in them.

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/rebasehelper/cli.py", line 128, in run
    app.run()
  File "/usr/lib/python3.7/site-packages/rebasehelper/application.py", line 802, in run
    self.patch_sources([old_sources, new_sources])
  File "/usr/lib/python3.7/site-packages/rebasehelper/application.py", line 421, in patch_sources
    **self.kwargs)
  File "/usr/lib/python3.7/site-packages/rebasehelper/patcher.py", line 329, in patch
    return cls._git_rebase()
  File "/usr/lib/python3.7/site-packages/rebasehelper/patcher.py", line 207, in _git_rebase
    if [l for l in f.readlines() if '<<<<<<<' in l]:
  File "/usr/lib64/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa1 in position 5925: invalid start byte
```