### PR TITLE
Make extra version mostly work

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -164,13 +164,14 @@ class Application:
         # check if argument passed as new source is a file or just a version
         if [True for ext in Archive.get_supported_archives() if self.conf.sources.endswith(ext)]:
             logger.verbose("argument passed as a new source is a file")
-            self.rebase_spec_file.set_version_using_archive(self.conf.sources)
+            version_string = self.spec_file.extract_version_from_archive_name(self.conf.sources,
+                                                                              self.spec_file.get_main_source())
         else:
             logger.verbose("argument passed as a new source is a version")
-            version, extra_version, separator = SpecFile.split_version_string(self.conf.sources)
-            self.rebase_spec_file.set_version(version)
-            self.rebase_spec_file.extra_version_separator = separator
-            self.rebase_spec_file.set_extra_version(extra_version)
+            version_string = self.conf.sources
+        version, extra_version = SpecFile.split_version_string(version_string, self.spec_file.header.version)
+        self.rebase_spec_file.set_version(version)
+        self.rebase_spec_file.set_extra_version(extra_version, version != self.spec_file.header.version)
 
         if not self.conf.skip_version_check and parse_version(self.rebase_spec_file.header.version) \
                 <= parse_version(self.spec_file.header.version):

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -173,8 +173,12 @@ class Application:
         self.rebase_spec_file.set_version(version)
         self.rebase_spec_file.set_extra_version(extra_version, version != self.spec_file.header.version)
 
-        if not self.conf.skip_version_check and parse_version(self.rebase_spec_file.header.version) \
-                <= parse_version(self.spec_file.header.version):
+        oldver = parse_version(self.spec_file.header.version)
+        newver = parse_version(self.rebase_spec_file.header.version)
+        oldex = self.spec_file.parse_release()[2]
+        newex = extra_version
+
+        if not self.conf.skip_version_check and (newver < oldver or (newver == oldver and newex == oldex)):
             raise RebaseHelperError("Current version is equal to or newer than the requested version, nothing to do.")
 
         self.rebase_spec_file.update_changelog(self.conf.changelog_entry)

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -665,9 +665,8 @@ class Application:
 
             results_store.set_result_message('fail', exception.msg)
         else:
-            result = "Rebase from {}-{} to {}-{} completed without an error".format(
-                self.spec_file.header.name, self.spec_file.header.version,
-                self.rebase_spec_file.header.name, self.rebase_spec_file.header.version)
+            result = "Rebase from {} to {} completed without an error".format(self.spec_file.get_NVR(),
+                                                                              self.rebase_spec_file.get_NVR())
             results_store.set_result_message('success', result)
 
         if self.rebase_spec_file:

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -909,7 +909,8 @@ class SpecFile:
                 result = []
                 for node in tree:
                     if node[0] == 't':
-                        result.append(node[1])
+                        # split text nodes on usual separators
+                        result.extend([t for t in re.split(r'(\.|-|_)', node[1]) if t])
                     elif node[0] == 'm':
                         m = '%{{{}}}'.format(node[1])
                         if MacroHelper.expand(m):

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -385,6 +385,9 @@ class SpecFile:
             if match:
                 return match.group(1)
 
+    def get_main_source(self):
+        return self._get_raw_source_string(self.main_source_index)
+
     ###########################
     # PATCHES RELATED METHODS #
     ###########################

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -260,8 +260,6 @@ class SpecFile:
         self.prep_section: str = ''
         self.patches: Dict[str, List[PatchObject]] = {}
         self.sources: List[str] = []
-        self.extra_version: str = ''
-        self.extra_version_separator: str = ''
         self.category: Optional[PackageCategory] = None
         self.spc: rpm.spec = RpmHelper.get_rpm_spec(self.path, self.sources_location)
         self.header: RpmHeader = RpmHeader(self.spc.sourceHeader)
@@ -324,13 +322,6 @@ class SpecFile:
         self.sources = self._get_spec_sources_list(self.spc)
         self.prep_section = self.spc.prep
         self.main_source_index = self._identify_main_source(self.spc)
-        # determine the extra_version
-        logger.debug("Updating the extra version")
-        _, self.extra_version, separator = SpecFile.extract_version_from_archive_name(
-            self.get_archive(),
-            self._get_raw_source_string(self.main_source_index))
-        self.extra_version_separator = separator
-
         self.patches = self._get_initial_patches()
         self.macros = MacroHelper.dump()
 

--- a/rebasehelper/tests/testing_files/rebase/test.spec
+++ b/rebasehelper/tests/testing_files/rebase/test.spec
@@ -9,7 +9,7 @@ Patch0:         applicable.patch
 Patch1:         conflicting.patch
 Patch2:         backported.patch
 
-BuildRequires:  gcc
+BuildRequires:  gcc make
 
 
 %description


### PR DESCRIPTION
This should fix rebasing from pre/post-release to a stable release, and from pre/post-release to a different pre/post-release. Rebasing from stable release to pre/post-release most likely requires modifying `Source0` tag, which is currently not implemented.