### PR TITLE
More SpecFile fixes

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -577,7 +577,7 @@ class SpecFile:
             disable_inapplicable: Whether to comment out inapplicable patches.
         """
         def is_comment(line):
-            if re.match(r'^#\s*[A-Za-z][A-Za-z0-9]+\s*:', line):
+            if re.match(r'^#\s*[A-Za-z][A-Za-z0-9]+\s*:(?!//)', line):
                 # ignore commented-out tag
                 return False
             return line.startswith('#')

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -671,6 +671,10 @@ class SpecFile:
         logger.verbose('Changing release to %s', release)
         self.set_tag('Release', '{}%{{?dist}}'.format(release), preserve_macros=True)
 
+    def set_release_number(self, release: str) -> None:
+        # deprecated, kept for backward compatibility
+        self.set_release(release)
+
     def set_extra_version(self, extra_version: Optional[str], version_changed: bool) -> None:
         """Updates SPEC file with the specified extra version.
 


### PR DESCRIPTION
* **Do not consider URL to be a commented-out tag**
  It's quite common to add comments with e.g. bugzilla URLs before `Patch` tags in a SPEC. These should of course be removed when removing the tag. Enhance the tag pattern not to match `http(s)://`.

* **Reintroduce `SpecFile.set_release_number()` for backward compatibility**
  This method is used by packit, so keep it, although the name is not accurate.