### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ env:
     - DISTRO=fedora-29
     - DISTRO=fedora-latest
     - DISTRO=fedora-rawhide
+before_install:
+    - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    - sudo apt-get update
+    - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 install: true
 before_script:
     - |

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -11,6 +11,7 @@ RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.co
   && dnf -y update \
   && dnf -y install \
     python36 \
+    python37 \
     python38 \
     python3 \
     python3-devel \


### PR DESCRIPTION
Since `stat` now uses `statx` syscall, it is necessary to run tests with docker version incorporating  https://github.com/moby/moby/pull/36417.

Also, `python3` defaults to `python38` on rawhide, so `python37` is missing and needs to be installed explicitly.