### PR TITLE
Default to all sections in Tags.filter()

### DIFF
--- a/rebasehelper/plugins/spec_hooks/replace_old_version.py
+++ b/rebasehelper/plugins/spec_hooks/replace_old_version.py
@@ -101,7 +101,7 @@ class ReplaceOldVersion(BaseSpecHook):
 
         subversion_patterns = cls._create_possible_replacements(old_version, new_version, replace_with_macro)
         examined_lines: Dict[str, Set[int]] = collections.defaultdict(set)
-        for tag in rebase_spec_file.tags.filter(section=None):
+        for tag in rebase_spec_file.tags.filter():
             examined_lines[tag.section].add(tag.line)
             value = rebase_spec_file.get_raw_tag_value(tag.name, tag.section)
             if not value or tag.name in cls.IGNORED_TAGS:

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -195,23 +195,23 @@ class SpecFile:
     # TAG HELPER METHODS #
     ######################
 
-    def tag(self, name: str, section: str = '%package') -> Optional[Tag]:
+    def tag(self, name: str, section: Optional[str] = None) -> Optional[Tag]:
         """Returns the first non-unique tag."""
         tags = self.tags.filter(section=section, name=name)
         return next(tags, None)
 
-    def get_raw_tag_value(self, tag_name: str, section: str = '%package') -> Optional[str]:
+    def get_raw_tag_value(self, tag_name: str, section: Optional[str] = None) -> Optional[str]:
         tag = self.tag(tag_name, section)
         if not tag:
             return None
-        return self.spec_content.section(section)[tag.line][slice(*tag.value_span)]
+        return self.spec_content.section(tag.section)[tag.line][slice(*tag.value_span)]
 
-    def set_raw_tag_value(self, tag_name: str, value: str, section: str = '%package') -> None:
+    def set_raw_tag_value(self, tag_name: str, value: str, section: Optional[str] = None) -> None:
         tag = self.tag(tag_name, section)
         if not tag:
             return
-        line = self.spec_content.section(section)[tag.line]
-        self.spec_content.section(section)[tag.line] = line[:tag.value_span[0]] + value + line[tag.value_span[1]:]
+        line = self.spec_content.section(tag.section)[tag.line]
+        self.spec_content.section(tag.section)[tag.line] = line[:tag.value_span[0]] + value + line[tag.value_span[1]:]
         # update span
         tag.value_span = (tag.value_span[0], tag.value_span[0] + len(value))
 

--- a/rebasehelper/tags.py
+++ b/rebasehelper/tags.py
@@ -114,9 +114,9 @@ class Tags(collections.abc.Sequence):
                         result.append(Tag(section, index, sanitize(m.group('name')), span, valid))
         return cast(Tuple[Tag], tuple(result))
 
-    def filter(self, section: Optional[str] = '%package', name: Optional[str] = None,
+    def filter(self, section: Optional[str] = None, name: Optional[str] = None,
                valid: Optional[bool] = True) -> Iterator[Tag]:
-        """Filters tags based on section, name or validity. Defaults to all valid tags in the preamble.
+        """Filters tags based on section, name or validity. Defaults to all valid tags in all sections.
 
         Args:
             section: If specified, includes tags only from this section.

--- a/rebasehelper/tests/test_tags.py
+++ b/rebasehelper/tests/test_tags.py
@@ -93,8 +93,8 @@ Requires: extradep
         assert tags[9] == Tag('%package utils', 0, 'Requires', (10, 28), False)
 
     def test_filter(self, tags):
-        assert len(list(tags.filter())) == 7
-        assert len(list(tags.filter(name='Patch*'))) == 3
-        assert len(list(tags.filter(valid=False))) == 0
-        assert len(list(tags.filter(section=None, valid=False))) == 1
-        assert len(list(tags.filter(section=None, name='Requires', valid=None))) == 3
+        assert len(list(tags.filter(section='%package'))) == 7
+        assert len(list(tags.filter(section='%package', name='Patch*'))) == 3
+        assert len(list(tags.filter(section='%package', valid=False))) == 0
+        assert len(list(tags.filter(valid=False))) == 1
+        assert len(list(tags.filter(name='Requires', valid=None))) == 3


### PR DESCRIPTION
As even Source and Patch tags can be in different sections than preamble, it makes more sense to default to all sections.