### PR TITLE
Implement parsing of %sourcelist and %patchlist

### DIFF
--- a/rebasehelper/spec_content.py
+++ b/rebasehelper/spec_content.py
@@ -87,6 +87,9 @@ class SpecContent:
                 content.append(line + '\n')
         return ''.join(content)
 
+    def __getitem__(self, index):
+        return self.sections[index][1]
+
     @classmethod
     def get_comment_span(cls, line: str, section: str) -> Tuple[int, int]:
         """Gets span of a comment depending on the section.

--- a/rebasehelper/spec_content.py
+++ b/rebasehelper/spec_content.py
@@ -62,6 +62,9 @@ class SpecContent:
         '%transfiletrigger',
         '%transfiletriggerun',
         '%transfiletriggerpostun',
+        '%end',
+        '%patchlist',
+        '%sourcelist',
     ]
 
     # Comments in these sections can only be on a separate line.

--- a/rebasehelper/tags.py
+++ b/rebasehelper/tags.py
@@ -114,6 +114,18 @@ class Tags(collections.abc.Sequence):
                         result.append(Tag(section, index, sanitize(m.group('name')), span, valid))
         return cast(Tuple[Tag], tuple(result))
 
+    @classmethod
+    def _filter(cls, tags: Tuple[Tag], section: Optional[str] = None, name: Optional[str] = None,
+                valid: Optional[bool] = True) -> Iterator[Tag]:
+        result = iter(tags)
+        if section is not None:
+            result = filter(lambda t: t.section == section.lower(), result)  # type: ignore
+        if name is not None:
+            result = filter(lambda t: fnmatch.fnmatchcase(t.name, name.capitalize()), result)  # type: ignore
+        if valid is not None:
+            result = filter(lambda t: t.valid == valid, result)
+        return result
+
     def filter(self, section: Optional[str] = None, name: Optional[str] = None,
                valid: Optional[bool] = True) -> Iterator[Tag]:
         """Filters tags based on section, name or validity. Defaults to all valid tags in all sections.
@@ -127,11 +139,4 @@ class Tags(collections.abc.Sequence):
             Iterator of matching Tag objects.
 
         """
-        result = iter(self.items)
-        if section is not None:
-            result = filter(lambda t: t.section == section.lower(), result)  # type: ignore
-        if name is not None:
-            result = filter(lambda t: fnmatch.fnmatchcase(t.name, name.capitalize()), result)  # type: ignore
-        if valid is not None:
-            result = filter(lambda t: t.valid == valid, result)
-        return result
+        return self._filter(self.items, section, name, valid)

--- a/rebasehelper/tests/public_api/test_tags.py
+++ b/rebasehelper/tests/public_api/test_tags.py
@@ -41,6 +41,6 @@ class TestTags:
         result = spec_object.tags.filter()
         assert isinstance(result, collections.Iterator)
         assert isinstance(next(result), Tag)
-        result = spec_object.tags.filter(section='%package', name='Source*', valid=True)
+        result = spec_object.tags.filter(section_index=0, section_name='%package', name='Source*', valid=True)
         assert isinstance(result, collections.Iterator)
         assert isinstance(next(result), Tag)

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -214,7 +214,7 @@ class TestSpecFile:
 
     def test_tags(self, spec_object):
         # sanity check
-        assert spec_object.tag('Name') == Tag('%package', 16, 'Name', (6, 10), True)
+        assert spec_object.tag('Name') == Tag(0, '%package', 16, 'Name', (6, 10), True)
         # no workaround
         assert spec_object.tag('Patch100') is None
         assert spec_object.tag('Patch101') is not None

--- a/rebasehelper/tests/test_tags.py
+++ b/rebasehelper/tests/test_tags.py
@@ -41,9 +41,20 @@ Patch01: patch0001.diff
 %{?!optimize:Patch999: extras.patch}
 %{?optimize:Patch999: extras-optimized.patch}
 
+%sourcelist
+   # test comment
+source2.zip
+
+%patchlist
+list.patch
+
 %Package libs
 Requires: %{name}-%{version}
 Requires: extradep
+Source3: source3.tar.gz
+
+%sourcelist
+source4.zip
 
 %if 0%{?with_utils:1}
 %package utils
@@ -60,9 +71,20 @@ Patch00: patch0000.diff
 Patch01: patch0001.diff
 Patch999: extras-optimized.patch
 
+%sourcelist
+   # test comment
+source2.zip
+
+%patchlist
+list.patch
+
 %Package libs
 Requires: test-0.1
 Requires: extradep
+Source3: source3.tar.gz
+
+%sourcelist
+source4.zip
 
     '''
 
@@ -80,7 +102,7 @@ Requires: extradep
         return Tags(SpecContent(self.RAW_CONTENT), SpecContent(self.PARSED_CONTENT))
 
     def test_tags(self, tags):
-        assert len(tags) == 10
+        assert len(tags) == 14
         assert tags[0] == Tag(0, '%package', 1, 'Name', (6, 10), True)
         assert tags[1] == Tag(0, '%package', 2, 'Version', (9, 12), True)
         assert tags[2] == Tag(0, '%package', 3, 'Source0', (8, 19), True)
@@ -88,9 +110,13 @@ Requires: extradep
         assert tags[4] == Tag(0, '%package', 5, 'Patch0', (9, 23), True,)
         assert tags[5] == Tag(0, '%package', 6, 'Patch1', (9, 23), True)
         assert tags[6] == Tag(0, '%package', 8, 'Patch999', (22, 44), True)
-        assert tags[7] == Tag(1, '%package libs', 0, 'Requires', (10, 28), True)
-        assert tags[8] == Tag(1, '%package libs', 1, 'Requires', (10, 18), True)
-        assert tags[9] == Tag(2, '%package utils', 0, 'Requires', (10, 28), False)
+        assert tags[7] == Tag(1, '%sourcelist', 1, 'Source2', (0, 11), True)
+        assert tags[8] == Tag(2, '%patchlist', 0, 'Patch1000', (0, 10), True)
+        assert tags[9] == Tag(3, '%package libs', 0, 'Requires', (10, 28), True)
+        assert tags[10] == Tag(3, '%package libs', 1, 'Requires', (10, 18), True)
+        assert tags[11] == Tag(3, '%package libs', 2, 'Source3', (9, 23), True)
+        assert tags[12] == Tag(4, '%sourcelist', 0, 'Source4', (0, 11), True)
+        assert tags[13] == Tag(5, '%package utils', 0, 'Requires', (10, 28), False)
 
     def test_filter(self, tags):
         assert len(list(tags.filter(section_name='%package'))) == 7

--- a/rebasehelper/tests/test_tags.py
+++ b/rebasehelper/tests/test_tags.py
@@ -81,20 +81,20 @@ Requires: extradep
 
     def test_tags(self, tags):
         assert len(tags) == 10
-        assert tags[0] == Tag('%package', 1, 'Name', (6, 10), True)
-        assert tags[1] == Tag('%package', 2, 'Version', (9, 12), True)
-        assert tags[2] == Tag('%package', 3, 'Source0', (8, 19), True)
-        assert tags[3] == Tag('%package', 4, 'Source1', (9, 29), True)
-        assert tags[4] == Tag('%package', 5, 'Patch0', (9, 23), True)
-        assert tags[5] == Tag('%package', 6, 'Patch1', (9, 23), True)
-        assert tags[6] == Tag('%package', 8, 'Patch999', (22, 44), True)
-        assert tags[7] == Tag('%package libs', 0, 'Requires', (10, 28), True)
-        assert tags[8] == Tag('%package libs', 1, 'Requires', (10, 18), True)
-        assert tags[9] == Tag('%package utils', 0, 'Requires', (10, 28), False)
+        assert tags[0] == Tag(0, '%package', 1, 'Name', (6, 10), True)
+        assert tags[1] == Tag(0, '%package', 2, 'Version', (9, 12), True)
+        assert tags[2] == Tag(0, '%package', 3, 'Source0', (8, 19), True)
+        assert tags[3] == Tag(0, '%package', 4, 'Source1', (9, 29), True)
+        assert tags[4] == Tag(0, '%package', 5, 'Patch0', (9, 23), True,)
+        assert tags[5] == Tag(0, '%package', 6, 'Patch1', (9, 23), True)
+        assert tags[6] == Tag(0, '%package', 8, 'Patch999', (22, 44), True)
+        assert tags[7] == Tag(1, '%package libs', 0, 'Requires', (10, 28), True)
+        assert tags[8] == Tag(1, '%package libs', 1, 'Requires', (10, 18), True)
+        assert tags[9] == Tag(2, '%package utils', 0, 'Requires', (10, 28), False)
 
     def test_filter(self, tags):
-        assert len(list(tags.filter(section='%package'))) == 7
-        assert len(list(tags.filter(section='%package', name='Patch*'))) == 3
-        assert len(list(tags.filter(section='%package', valid=False))) == 0
+        assert len(list(tags.filter(section_name='%package'))) == 7
+        assert len(list(tags.filter(section_name='%package', name='Patch*'))) == 3
+        assert len(list(tags.filter(section_name='%package', valid=False))) == 0
         assert len(list(tags.filter(valid=False))) == 1
         assert len(list(tags.filter(name='Requires', valid=None))) == 3


### PR DESCRIPTION
Related: #622 (this just implements parsing)

This just adds parsing support, integration with other parts of rebase-helper may not be perfect. For example if rebase-helper removes a patch from preamble and `%patchlist` is present and the patches are applied in `%prep` using `%patch` macro, it is going to break. But I think this deserves its own issue/PR.

Also, I haven't found a way how to support conditionalized sources in `%sourcelist` or `%patchlist`. Say the section looks like this:

```
%sourcelist
source2.tar.gz
%if 0%{?source:1}
source3.tar
%endif
```

I don't think there is a consistent way to differentiate between the source and the `%if` macro (neither are in parsed spec object).