### PR TITLE
Handle null release name in CommitHashUpdater

### DIFF
--- a/rebasehelper/plugins/spec_hooks/commit_hash_updater.py
+++ b/rebasehelper/plugins/spec_hooks/commit_hash_updater.py
@@ -62,7 +62,7 @@ class CommitHashUpdater(BaseSpecHook):
         version = spec_file.header.version
         tag_name = None
         for release in data:
-            if version in release.get('name'):
+            if version in release.get('name', ''):
                 tag_name = release.get('tag_name')
                 break
 


### PR DESCRIPTION
Example of a problematic release: https://api.github.com/repos/KhronosGroup/glslang/releases/15961606 (caused traceback in batch rebase)