### PR TITLE
Add Python 3.9 compatibility.

### DIFF
--- a/rebasehelper/plugins/checkers/pkgdiff.py
+++ b/rebasehelper/plugins/checkers/pkgdiff.py
@@ -116,11 +116,11 @@ class PkgDiff(BaseChecker):
         XML_FILES = ['files.xml', 'symbols.xml']
         if old_version is None:
             old_version = results_store.get_old_build().get('version')
-            if old_version is '':
+            if old_version == '':
                 old_version = cls._get_rpm_info('version', results_store.get_old_build()['rpm'])
         if new_version is None:
             new_version = results_store.get_new_build().get('version')
-            if new_version is '':
+            if new_version == '':
                 new_version = cls._get_rpm_info('version', results_store.get_new_build()['rpm'])
 
         for tag in cls.CHECKER_TAGS:

--- a/rebasehelper/tests/plugins/test_output_tools.py
+++ b/rebasehelper/tests/plugins/test_output_tools.py
@@ -192,6 +192,6 @@ Binary packages and logs are in directory rebase-helper-results/new-build/RPM:
         JSON.print_summary(results_file_path, results_store)
 
         with open(results_file_path) as f:
-            json_dict = json.load(f, encoding='utf-8')
+            json_dict = json.load(f)
             # in Python2 strings in json decoded dict are Unicode, which would make the test fail
             assert json_dict == json.loads(json.dumps(self.get_expected_json_output()))


### PR DESCRIPTION
* Fix SyntaxWarning due to comparison of literals using is.

```
find . -iname '*.py'  | xargs -P 4 -I{} python3.8 -Wall -m py_compile {}
./rebasehelper/plugins/checkers/pkgdiff.py:119: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if old_version is '':
./rebasehelper/plugins/checkers/pkgdiff.py:123: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if new_version is '':
```

* Remove deprecated encoding parameter used in `json.load` for Python 3.9 .

Fixes #770 