### PR TITLE
[SpecFile.reload()] don't _read_spec_content() before update()

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -996,7 +996,6 @@ class SpecFile:
 
     def reload(self):
         """Reloads the whole Spec file."""
-        self._read_spec_content()
         self.update()
 
     def save(self):


### PR DESCRIPTION
The SpecContent instance which _read_spec_content() returns
is thrown away so the call is useless.
update() calls it too, but saves the instance to self.spec_content