### PR TITLE
Skip deleted files when detecting unresolved conflicts

### DIFF
--- a/rebasehelper/patcher.py
+++ b/rebasehelper/patcher.py
@@ -203,9 +203,13 @@ class Patcher:
                     # check for unresolved conflicts
                     unresolved = []
                     for file in unmerged:
-                        with open(os.path.join(cls.old_sources, file), 'rb') as f:
-                            if [l for l in f if b'<<<<<<<' in l]:
-                                unresolved.append(file)
+                        try:
+                            with open(os.path.join(cls.old_sources, file), 'rb') as f:
+                                if [l for l in f if b'<<<<<<<' in l]:
+                                    unresolved.append(file)
+                        except FileNotFoundError:
+                            # skip deleted files
+                            continue
                     if unresolved:
                         if InputHelper.get_message('There are still unresolved conflicts. '
                                                    'Do you want to skip this patch',


### PR DESCRIPTION
As opposed to normal merge conflicts, deleted merge conflicts can be resolved by deleting a file.
Account for such case.

Example:

```
Normal merge conflict for 'doc/fixinfo.sh':
  {local}: modified file
  {remote}: modified file
4 files to edit

Deleted merge conflict for 'doc/groff.info-2':
  {local}: deleted
  {remote}: modified file
Use (m)odified or (d)eleted file, or (a)bort? d
```