### PR TITLE
Add Tag.__str__()

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,4 +1,3 @@
-specfile_path: rebase-helper.spec
 current_version_command: ["python3", "setup.py", "--version"]
 create_tarball_command: ["python3", "setup.py", "sdist", "--base-name", "rebase-helper", "--dist-dir", "."]
 jobs:

--- a/rebasehelper/tags.py
+++ b/rebasehelper/tags.py
@@ -51,6 +51,18 @@ class Tag:
                 self.valid == other.valid and
                 self.index == other.index)
 
+    def __str__(self) -> str:
+        return (
+            "Tag("
+            f"section_index='{self.section_index}', "
+            f"section_name='{self.section_name}', "
+            f"line='{self.line}', "
+            f"name='{self.name}', "
+            f"value_span='{self.value_span}', "
+            f"valid='{self.valid}', "
+            f"index='{self.index}')"
+        )
+
 
 class Tags(collections.abc.Sequence):
     def __init__(self, raw_content: SpecContent, parsed_content: SpecContent) -> None:


### PR DESCRIPTION
When I was debugging some rebase-helper related code I needed to see tags values, so I added this `Tag.__str__()`.

This PR also removes `specfile_path` from `.packit.yml` to verify that the problem we saw in https://github.com/rebase-helper/rebase-helper/pull/785#issuecomment-593292961 is fixed.