### PR TITLE
Prevent git commands from launching an interactive editor

### DIFF
--- a/rebasehelper/patcher.py
+++ b/rebasehelper/patcher.py
@@ -323,6 +323,8 @@ class Patcher:
         repo.git.config('rebasehelper.state', state, local=True)
         repo.git.config('user.name', GitHelper.get_user(), local=True)
         repo.git.config('user.email', GitHelper.get_email(), local=True)
+        # prevent git commands from launching an interactive editor
+        repo.git.config('core.editor', 'true', local=True)
         repo.git.add(all=True)
         repo.index.commit('Initial commit', skip_hooks=True)
         return repo, state


### PR DESCRIPTION
Since git switched its rebase backend from apply to merge, it launches a commit message editor on `git rebase --continue`. This causes **rebase-helper** to hang indefinitely.
Prevent that from happening by explicitly reconfiguring the editor in the git repo.