### PR TITLE
Allow tilde as extra version separator

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -876,7 +876,7 @@ class SpecFile:
             RebaseHelperError in case passed version string is not valid.
 
         """
-        version_re = re.compile(r'^(\d+[.\d]*\d+|\d+)(\.|-|_|\+)?(\w+)?$')
+        version_re = re.compile(r'^(\d+[.\d]*\d+|\d+)(\.|-|_|\+|~)?(\w+)?$')
         m = version_re.match(version_string)
         if not m:
             raise RebaseHelperError('Invalid version string: {}'.format(version_string))

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -128,6 +128,7 @@ class TestSpecFile:
         assert SpecFile.split_version_string('1.0.1rc1', '1.0.1') == ('1.0.1', 'rc1')
         assert SpecFile.split_version_string('1.1.3-rc6', '1.1.3') == ('1.1.3', 'rc6')
         assert SpecFile.split_version_string('1.1.3_rc6', '1.1.3') == ('1.1.3', 'rc6')
+        assert SpecFile.split_version_string('1.1.3~rc6', '1.1.3') == ('1.1.3', 'rc6')
         assert SpecFile.split_version_string('1.1.1d', '1.1.1c') == ('1.1.1d', None)
 
     def test_extract_version_from_archive_name(self):


### PR DESCRIPTION
RPM allows the use of tilde in Version tag. Moreover, the Fedora
Packaging Guidelines mention tilde as a possible way of specifying
prereleases. See the following link for more information:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/