### PR TITLE
Remove excessive blank lines when removing patches

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -425,6 +425,9 @@ class SpecFile:
                 # ignore commented-out tag
                 return False
             return line.startswith('#')
+
+        def is_empty(line):
+            return not line or line.isspace()
         if not patches:
             return None
         removed_patches = []
@@ -450,7 +453,10 @@ class SpecFile:
                 removed_patches.append(tag.index)
                 # find associated comments
                 i = tag.line
-                while i > 0 and is_comment(section[i - 1]):
+                # if the tag is followed by an empty line remove empty lines
+                # in front of the tag to avoid unnecessary blank lines in the spec.
+                blank_follows = i + 1 < len(section) and is_empty(section[i + 1])
+                while i > 0 and (is_comment(section[i - 1]) or blank_follows and is_empty(section[i - 1])):
                     i -= 1
                 remove_lines[tag.section_index].append((i, tag.line + 1))
                 continue

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -351,9 +351,37 @@ class TestSpecFile:
         %patch1 -p3
         """),
         ),
+        (
+            {
+                'removed_patches': [],
+                'spec_content': dedent("""\
+                    Patch0:     0.patch
+                    
+                    
+                    # Patch comment
+                    # line2
+                    Patch1:     1.patch
+                    
+                    Patch2:     2.patch
+                    """),
+            },
+            {
+                'patches':
+                    {
+                        'deleted': ['1.patch'],
+                    },
+                'disable_inapplicable': False,
+            },
+            dedent("""\
+            Patch0:     0.patch
+            
+            Patch2:     2.patch
+            """),
+        ),
     ], ids=[
         'do_not_disable_inapplicable',
         'disable_inapplicable',
+        'comments_and_blank_lines',
     ])
     def test_write_updated_patches(self, mocked_spec_object, kwargs, expected_content):
         mocked_spec_object.write_updated_patches(**kwargs)


### PR DESCRIPTION
This is mainly a cosmetic change to avoid leaving 2 or more blank lines
in the specfile after removing a patch that is surrounded by blank
lines.