### PR TITLE
Rename sources and patches if necessary

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -158,9 +158,7 @@ class Application:
                                         'and no SOURCES argument specified!')
 
         # Prepare rebased_sources_dir
-        self.rebased_repo = self._prepare_rebased_repository(self.spec_file.patches,
-                                                             self.execution_dir,
-                                                             self.rebased_sources_dir)
+        self.rebased_repo = self._prepare_rebased_repository()
 
         # check if argument passed as new source is a file or just a version
         if [True for ext in Archive.get_supported_archives() if self.conf.sources.endswith(ext)]:
@@ -443,24 +441,23 @@ class Application:
             for src in [s for s in sources if not match(s)]:
                 f.write(os.path.sep + src + '\n')
 
-    @classmethod
-    def _prepare_rebased_repository(cls, patches, execution_dir, rebased_sources_dir):
+    def _prepare_rebased_repository(self):
         """
         Initialize git repository in the rebased directory
         :return: git.Repo instance of rebased_sources
         """
-        for patch in patches['applied'] + patches['not_applied']:
-            shutil.copy(patch.path, rebased_sources_dir)
+        for patch in self.spec_file.get_applied_patches() + self.spec_file.get_not_used_patches():
+            shutil.copy(patch.path, self.rebased_sources_dir)
 
-        sources = os.path.join(execution_dir, 'sources')
+        sources = os.path.join(self.execution_dir, 'sources')
         if os.path.isfile(sources):
-            shutil.copy(sources, rebased_sources_dir)
+            shutil.copy(sources, self.rebased_sources_dir)
 
-        gitignore = os.path.join(execution_dir, '.gitignore')
+        gitignore = os.path.join(self.execution_dir, '.gitignore')
         if os.path.isfile(gitignore):
-            shutil.copy(gitignore, rebased_sources_dir)
+            shutil.copy(gitignore, self.rebased_sources_dir)
 
-        repo = git.Repo.init(rebased_sources_dir)
+        repo = git.Repo.init(self.rebased_sources_dir)
         repo.git.config('user.name', GitHelper.get_user(), local=True)
         repo.git.config('user.email', GitHelper.get_email(), local=True)
         repo.git.add(all=True)

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -26,6 +26,7 @@ import fnmatch
 import logging
 import os
 import shutil
+import urllib.parse
 from typing import Any, Dict, List, Optional, cast
 
 import git  # type: ignore
@@ -446,6 +447,13 @@ class Application:
         Initialize git repository in the rebased directory
         :return: git.Repo instance of rebased_sources
         """
+        for source, _, source_type in self.spec_file.spc.sources:
+            # copy only existing local sources
+            if not urllib.parse.urlparse(source).scheme and source_type == 1:
+                source_path = os.path.join(self.execution_dir, source)
+                if os.path.isfile(source_path):
+                    shutil.copy(source_path, self.rebased_sources_dir)
+
         for patch in self.spec_file.get_applied_patches() + self.spec_file.get_not_used_patches():
             shutil.copy(patch.path, self.rebased_sources_dir)
 

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -404,13 +404,14 @@ class SpecFile:
             i += 1
 
     @saves
-    def update_paths_to_patches(self) -> None:
-        """Fixes paths of patches to make them usable in SPEC file location"""
+    def update_paths_to_sources_and_patches(self) -> None:
+        """Fixes paths of patches and sources to make them usable in SPEC file location"""
         rebased_sources_path = os.path.join(constants.RESULTS_DIR, constants.REBASED_SOURCES_DIR)
-        for tag in self.tags.filter(name='Patch*'):
-            value = self.get_raw_tag_value(tag.name)
-            if value:
-                self.set_raw_tag_value(tag.name, value.replace(rebased_sources_path + os.path.sep, ''))
+        for tag_type in ('Patch', 'Source'):
+            for tag in self.tags.filter(name='{}*'.format(tag_type)):
+                value = self.get_raw_tag_value(tag.name)
+                if value and not urllib.parse.urlparse(value).scheme:
+                    self.set_raw_tag_value(tag.name, value.replace(rebased_sources_path + os.path.sep, ''))
 
     @saves
     def write_updated_patches(self, patches: Dict[str, List[str]], disable_inapplicable: bool) -> None:

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -392,11 +392,11 @@ class TestSpecFile:
             'spec_content': 'Patch5: rebase-helper-results/rebased-sources/test-testing5.patch\n'
         }
     ])
-    def test_update_paths_to_patches(self, mocked_spec_object):
+    def test_update_paths_to_sources_and_patches(self, mocked_spec_object):
         line = [l for l in mocked_spec_object.spec_content.section('%package') if l.startswith('Patch5')][0]
         assert 'rebased-sources' in line
 
-        mocked_spec_object.update_paths_to_patches()
+        mocked_spec_object.update_paths_to_sources_and_patches()
 
         line = [l for l in mocked_spec_object.spec_content.section('%package') if l.startswith('Patch5')][0]
         assert 'rebased-sources' not in line


### PR DESCRIPTION
Names of local Sources and Patches may change between 2 versions (for example when %{version} macro is used in their names). This could lead to a failed rebase, SRPM build will fail.

Try to handle the situation by renaming the patches and sources in rebased-sources directory, changing their paths in specfile and then reverting the names back.