### PR TITLE
Add a test for patch renaming

### DIFF
--- a/rebasehelper/tests/testing_files/rebase/test.spec
+++ b/rebasehelper/tests/testing_files/rebase/test.spec
@@ -8,6 +8,7 @@ Source0:        https://integration:4430/pkgs/%{name}/%{name}-%{version}.tar.gz
 Patch0:         applicable.patch
 Patch1:         conflicting.patch
 Patch2:         backported.patch
+Patch3:         renamed-%{version}.patch
 
 BuildRequires:  gcc make
 


### PR DESCRIPTION
Incorporating the test for the new feature into the existing test turned out to be easier than I expected. I can't think of any other use cases that would need to be tested, so it isn't necessary to create a separate test (at least for now)

Resolves: #807 