### PR TITLE
Fix rpminspect checker

### DIFF
--- a/rebase-helper.spec
+++ b/rebase-helper.spec
@@ -42,7 +42,7 @@ Recommends:     licensecheck
 Recommends:     rpmlint
 Recommends:     libabigail
 Recommends:     pkgdiff >= 1.6.3
-Recommends:     rpminspect
+Recommends:     rpminspect-data-fedora
 
 
 %description

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -685,6 +685,8 @@ class Application:
                                                    **kwargs)
                 if data:
                     results[checker_name] = data
+            except RebaseHelperError as e:
+                logger.error(e.msg)
             except CheckerNotFoundError:
                 logger.error("Rebase-helper did not find checker '%s'.", checker_name)
 

--- a/rebasehelper/plugins/checkers/rpminspect.py
+++ b/rebasehelper/plugins/checkers/rpminspect.py
@@ -63,7 +63,7 @@ class Rpminspect(BaseChecker):  # pylint: disable=abstract-method
     """
     DEFAULT: bool = True
 
-    CMD: str = 'rpminspect'
+    CMD: str = 'rpminspect-fedora'
 
     BAD_CHECK: str = 'BAD'
     VERIFY_CHECK: str = 'VERIFY'


### PR DESCRIPTION
* Do not retry build when a checker fails
* Explicitly specify config file path for rpminspect (see Fedora bug [#1881909](https://bugzilla.redhat.com/show_bug.cgi?id=1881909)).