### PR TITLE
Fix updating build dict when getting old build from Koji

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -556,11 +556,11 @@ class Application:
                 os.makedirs(results_dir)
                 if koji_build_id:
                     session = KojiHelper.create_session()
-                    build_dict['srpm'], build_dict['logs'] = KojiHelper.download_build(session,
-                                                                                       koji_build_id,
-                                                                                       results_dir,
-                                                                                       arches=['src'])
-
+                    srpms, logs = KojiHelper.download_build(session,
+                                                            koji_build_id,
+                                                            results_dir,
+                                                            arches=['src'])
+                    build_dict['srpm'], build_dict['logs'] = srpms[0], logs
                 else:
                     build_dict.update(builder.build(spec, results_dir, **build_dict))
                 build_dict = self._sanitize_build_dict(build_dict)


### PR DESCRIPTION
It is expected that build dict contains a single SRPM per build, but `KojiHelper.download_build()` returns a list of packages. Fix that.

Fixes: #825 