### PR TITLE
Change approach to lookaside cache servers

### DIFF
--- a/rebasehelper/tests/helpers/test_lookaside_cache_helper.py
+++ b/rebasehelper/tests/helpers/test_lookaside_cache_helper.py
@@ -86,5 +86,4 @@ class TestLookasideCacheHelper:
                                             '',
                                             filename,
                                             hashtype,
-                                            hsh,
-                                            None)
+                                            hsh)


### PR DESCRIPTION
Majority of supported lookaside cache servers currently don't handle chunked POST requests properly, so special-case the only one that does. Also, always try to use opportunistic SPNEGO authentication first, to avoid having yet another special case.
