### PR TITLE
Use C locale for updating %changelog

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -26,6 +26,7 @@ import argparse
 import collections
 import enum
 import itertools
+import locale
 import logging
 import os
 import re
@@ -1074,7 +1075,14 @@ class SpecFile:
                                            ver=self.header.version,
                                            rel=self.get_release())
         evr = evr[2:] if evr.startswith('0:') else evr
-        new_record.append('* {day} {name} <{email}> - {evr}'.format(day=today.strftime('%a %b %d %Y'),
+        # %changelog entries are always in the C locale
+        old_locale = locale.getlocale(locale.LC_TIME)
+        try:
+            locale.setlocale(locale.LC_TIME, "C")
+            day=today.strftime('%a %b %d %Y')
+        finally:
+            locale.setlocale(locale.LC_TIME, old_locale)
+        new_record.append('* {day} {name} <{email}> - {evr}'.format(day=day,
                                                                     name=GitHelper.get_user(),
                                                                     email=GitHelper.get_email(),
                                                                     evr=evr))

--- a/rebasehelper/tests/public_api/test_specfile.py
+++ b/rebasehelper/tests/public_api/test_specfile.py
@@ -22,7 +22,6 @@
 #          Nikola Forró <nforro@redhat.com>
 #          František Nečas <fifinecas@seznam.cz>
 
-import locale
 import os
 import shutil
 
@@ -48,18 +47,6 @@ class TestSpecFile:
     def test_update_changelog(self, spec_object):
         assert spec_object.update_changelog('test2') is None
         assert spec_object.update_changelog(changelog_entry='test') is None
-
-    def test_get_new_log_with_non_c_locale(self, spec_object):
-        # Changelogs should be identical no matter what locale
-        changelog = spec_object.get_new_log("test2")
-        for l in locale.locale_alias:
-            try:
-                locale.setlocale(locale.LC_TIME, l)
-                # Prevents us from trying out strange locale aliases that fail
-                locale.setlocale(locale.LC_TIME, locale.getlocale(locale.LC_TIME))
-            except:
-                continue
-            assert changelog == spec_object.get_new_log("test2")
 
     def test_set_version(self, spec_object):
         assert spec_object.set_version('1.2.3.4') is None

--- a/rebasehelper/tests/public_api/test_specfile.py
+++ b/rebasehelper/tests/public_api/test_specfile.py
@@ -22,6 +22,7 @@
 #          Nikola Forró <nforro@redhat.com>
 #          František Nečas <fifinecas@seznam.cz>
 
+import locale
 import os
 import shutil
 
@@ -47,6 +48,18 @@ class TestSpecFile:
     def test_update_changelog(self, spec_object):
         assert spec_object.update_changelog('test2') is None
         assert spec_object.update_changelog(changelog_entry='test') is None
+
+    def test_get_new_log_with_non_c_locale(self, spec_object):
+        # Changelogs should be identical no matter what locale
+        changelog = spec_object.get_new_log("test2")
+        for l in locale.locale_alias:
+            try:
+                locale.setlocale(locale.LC_TIME, l)
+                # Prevents us from trying out strange locale aliases that fail
+                locale.setlocale(locale.LC_TIME, locale.getlocale(locale.LC_TIME))
+            except:
+                continue
+            assert changelog == spec_object.get_new_log("test2")
 
     def test_set_version(self, spec_object):
         assert spec_object.set_version('1.2.3.4') is None

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -22,6 +22,7 @@
 #          Nikola Forró <nforro@redhat.com>
 #          František Nečas <fifinecas@seznam.cz>
 
+import locale
 import os
 from typing import List
 from textwrap import dedent
@@ -565,3 +566,15 @@ class TestSpecFile:
         spec_object.set_tag(tag, value, preserve_macros=preserve_macros)
         for line in lines_preserve if preserve_macros else lines:
             assert line in spec_object.spec_content.section('%package')
+
+    def test_get_new_log_with_non_c_locale(self, spec_object):
+        # Changelogs should be identical no matter what locale
+        changelog = spec_object.get_new_log("test2")
+        for l in locale.locale_alias:
+            try:
+                locale.setlocale(locale.LC_TIME, l)
+                # Prevents us from trying out strange locale aliases that fail
+                locale.setlocale(locale.LC_TIME, locale.getlocale(locale.LC_TIME))
+            except locale.Error:
+                continue
+            assert changelog == spec_object.get_new_log("test2")


### PR DESCRIPTION
Having the wrong locale running on your machine shouldn't
result in a changelog with invalid syntax or foreign characters.

Example of a bad date here:

https://src.fedoraproject.org/rpms/oci-kvm-hook/pull-request/2#request_diff

Technically setlocale() is not threadsafe. However it is unclear
whether this is a problem for rebase-helper. If it is a problem,
then we must replace strftime() usage in order to fix this problem.

The test aims to be reproducible, despite every system having all
sorts of different locales installed.