### PR TITLE
Add glibc-langpack-de to base images

### DIFF
--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -1,4 +1,4 @@
-FROM rebasehelper/base-image:fedora-latest
+FROM quay.io/rebasehelper/base-image:fedora-latest
 
 COPY containers/entrypoint.sh /entrypoint.sh
 

--- a/containers/Containerfile.base.fedora-latest
+++ b/containers/Containerfile.base.fedora-latest
@@ -13,6 +13,8 @@ RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.co
     python3-tox \
     # needed for setup
     python3-setuptools_scm_git_archive \
+    # needed for test_get_new_log_with_non_c_locale
+    glibc-langpack-de \
     redhat-rpm-config \
     libxml2-devel \
     libxslt-devel \

--- a/containers/Containerfile.base.fedora-rawhide
+++ b/containers/Containerfile.base.fedora-rawhide
@@ -13,6 +13,8 @@ RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.co
     python3-tox \
     # needed for setup
     python3-setuptools_scm_git_archive \
+    # needed for test_get_new_log_with_non_c_locale
+    glibc-langpack-de \
     redhat-rpm-config \
     libxml2-devel \
     libxslt-devel \


### PR DESCRIPTION
`test_get_new_log_with_non_c_locale` requires at least one non-English locale to be able to actually test anything, since there is only C locale in Fedora container images.

Also make rebase-helper container use image from quay.io.