### PR TITLE
Use Fedora registry for Fedora images

### DIFF
--- a/containers/Containerfile.base.fedora-latest
+++ b/containers/Containerfile.base.fedora-latest
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:latest
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf \
   # update GPG keys first in case some of them are missing

--- a/containers/Containerfile.base.fedora-rawhide
+++ b/containers/Containerfile.base.fedora-rawhide
@@ -1,4 +1,4 @@
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf \
   # update GPG keys first in case some of them are missing


### PR DESCRIPTION
Automatic builds on quay.io seem to have trouble pulling Fedora images from the default registry (presumably docker.io). This should solve it.