### PR TITLE
Fix macro value detection in set_tag

### DIFF
--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -531,29 +531,45 @@ class TestSpecFile:
             ],
         ),
         (
-                'Patch1000',
-                '0.8.b5%{?dist}',
-                [
-                    '%global prever b4',
-                    'Patch1000: 0.8.b5%{?dist}',
-                ],
-                [
-                    '%global prever b5',
-                    'Patch1000: 0.8.%{?prever}%{?dist}',
-                ],
+            'Patch1000',
+            '0.8.b5%{?dist}',
+            [
+                '%global prever b4',
+                'Patch1000: 0.8.b5%{?dist}',
+            ],
+            [
+                '%global prever b5',
+                'Patch1000: 0.8.%{?prever}%{?dist}',
+            ],
         ),
         (
-                'Patch1001',
-                '1.22.2',
-                [
-                    '%global branch 1.22',
-                    'Patch1001: 1.22.2',
-                ],
-                [
-                    '%global branch 1.22',
-                    'Patch1001: %{branch}.2',
-                ],
+            'Patch1001',
+            '1.22.2',
+            [
+                '%global branch 1.22',
+                'Patch1001: 1.22.2',
+            ],
+            [
+                '%global branch 1.22',
+                'Patch1001: %{branch}.2',
+            ],
         ),
+        (
+            'URL',
+            'http://testing2.org',
+            [
+                '%global domain testing',
+                '%global address %{domain}.org',
+                '%global full_address http://%{address}',
+                'URL: http://testing2.org',
+            ],
+            [
+                '%global domain testing2',
+                '%global address %{domain}.org',
+                '%global full_address http://%{address}',
+                'URL: %{full_address}',
+            ],
+        )
     ], ids=[
         'Summary=>"A testing SPEC file..."',
         'Version=>"1.1.8"',
@@ -561,6 +577,7 @@ class TestSpecFile:
         'Source8=>"https://github.com/rebase-helper/rebase-helper/archive/..."',
         'Patch1000=>"0.8.b5%{?dist}"',
         'Patch1001=>"1.22.2"',
+        'URL=>"http://testing2.org"',
     ])
     def test_set_tag(self, spec_object, preserve_macros, tag, value, lines, lines_preserve):
         spec_object.set_tag(tag, value, preserve_macros=preserve_macros)

--- a/rebasehelper/tests/testing_files/test.spec
+++ b/rebasehelper/tests/testing_files/test.spec
@@ -19,7 +19,12 @@ Version: %{version}
 Release: %{release_str}
 License: GPL2+
 Group: System Environment
-URL: http://testing.org
+
+# Regression test for #855: https://github.com/rebase-helper/rebase-helper/issues/855
+%global domain testing
+%global address %{domain}.org
+%global full_address http://%{address}
+URL: %{full_address}
 
 # Note: non-current tarballs get moved to the history/ subdirectory,
 # so look there if you fail to retrieve the version you want


### PR DESCRIPTION
Resolves: https://github.com/rebase-helper/rebase-helper/issues/855

Tried on the repo @TomasTomecek linked in the issue and it seems to work correctly now (also added a test that struggled from the same problem)

Previously, the regular expression for finding macro definitions didn't
correctly consider the possibility of having multiple macros inside
value of a macro (e.g. %{major}.%{minor}) resulting in incorrect value
parsing in some cases where macro definitions ended with regular string
characters as found in the following reproducer:

    %global general_version %{pybasever}.5
    #global prerel ...
    %global upstream_version %{general_version}%{?prerel}

The value of 'general_version' macro would previously span across all
three lines due to greedy matching and re.DOTALL which resulted in
incorrect behaviour (infinite recursion in this case).

Change the regex to correctly expect the possibility of multiple macros
along with normal text around as well. Allow line breaks only in the
body of a macro (that could for example be %{lua: ...}) using [\s\S]
instead of re.DOTALL and prohibit line breaks elsewhere.