### PR TITLE
Fix licensecheck availability test

### DIFF
--- a/rebasehelper/plugins/checkers/licensecheck.py
+++ b/rebasehelper/plugins/checkers/licensecheck.py
@@ -49,7 +49,7 @@ class LicenseCheck(BaseChecker):
     @classmethod
     def is_available(cls):
         try:
-            return ProcessHelper.run_subprocess([cls.CMD, '--help'], output_file=ProcessHelper.DEV_NULL) == 0
+            return ProcessHelper.run_subprocess([cls.CMD, '--version'], output_file=ProcessHelper.DEV_NULL) == 0
         except (IOError, OSError):
             return False
 


### PR DESCRIPTION
Since version 3.2.0, `licensecheck --help` exits with 1 instead of 0. Switch to `licensecheck --version` that seems to have consistent exit code.