### PR TITLE
Make container with tests privileged

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -6,8 +6,7 @@ services:
         build:
             context: ..
             dockerfile: containers/Containerfile.tests
-        cap_add:
-            - SYS_ADMIN
+        privileged: true
         environment:
             - PYTEST_ADDOPTS
             - TOXENV


### PR DESCRIPTION
Without making it privileged, tests using mock fail in Github Actions.
This used to work in Travis CI but apparently Github uses a newer OS or
docker version.

This fixes the behaviour, see https://github.com/rebase-helper/rebase-helper/actions/runs/1026615062 