### PR TITLE
Fixes based on pylint

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -472,7 +472,7 @@ class Application:
         if not os.path.isfile(gitignore):
             return
 
-        with open(gitignore) as f:
+        with open(gitignore, encoding=constants.ENCODING) as f:
             entries = f.readlines()
 
         def match(source):
@@ -482,7 +482,7 @@ class Application:
                     return True
             return False
 
-        with open(gitignore, 'a') as f:
+        with open(gitignore, 'a', encoding=constants.ENCODING) as f:
             for src in [s for s in sources if not match(s)]:
                 f.write(os.path.sep + src + '\n')
 

--- a/rebasehelper/completion.py
+++ b/rebasehelper/completion.py
@@ -26,6 +26,7 @@ import re
 import sys
 
 from rebasehelper.cli import CLI
+from rebasehelper.constants import ENCODING
 from rebasehelper.archive import Archive
 
 
@@ -86,10 +87,10 @@ def replace_placeholders(s, **kwargs):
 def main():
     if len(sys.argv) != 3:
         return 1
-    with open(sys.argv[1]) as f:
+    with open(sys.argv[1], encoding=ENCODING) as f:
         s = f.read()
     s = replace_placeholders(s, **Completion.dump())
-    with open(sys.argv[2], 'w') as f:
+    with open(sys.argv[2], 'w', encoding=ENCODING) as f:
         f.write(s)
     return 0
 

--- a/rebasehelper/constants.py
+++ b/rebasehelper/constants.py
@@ -52,4 +52,6 @@ GIT_CONFIG: str = '.gitconfig'
 CONFIG_PATH: str = '$XDG_CONFIG_HOME'
 CONFIG_FILENAME: str = 'rebase-helper.cfg'
 
-SYSTEM_ENCODING: str = locale.getpreferredencoding()
+# Preferred system encoding, will most likely be UTF-8 on RHEL/Fedora
+# but try to maintain compatibility even if it was different.
+ENCODING: str = locale.getpreferredencoding()

--- a/rebasehelper/helpers/console_helper.py
+++ b/rebasehelper/helpers/console_helper.py
@@ -34,7 +34,7 @@ import tty
 
 import colors  # type: ignore
 
-from rebasehelper.constants import SYSTEM_ENCODING
+from rebasehelper.constants import ENCODING
 
 
 class ConsoleHelper:
@@ -229,11 +229,11 @@ class ConsoleHelper:
             if self._stdout_tmp:
                 self._stdout_tmp.flush()
                 self._stdout_tmp.seek(0, io.SEEK_SET)
-                self.stdout = self._stdout_tmp.read().decode(SYSTEM_ENCODING)
+                self.stdout = self._stdout_tmp.read().decode(ENCODING)
             if self._stderr_tmp:
                 self._stderr_tmp.flush()
                 self._stderr_tmp.seek(0, io.SEEK_SET)
-                self.stderr = self._stderr_tmp.read().decode(SYSTEM_ENCODING)
+                self.stderr = self._stderr_tmp.read().decode(ENCODING)
 
             if self._stdout_tmp:
                 self._stdout_tmp.close()

--- a/rebasehelper/helpers/lookaside_cache_helper.py
+++ b/rebasehelper/helpers/lookaside_cache_helper.py
@@ -37,6 +37,7 @@ import requests_gssapi  # type: ignore
 from urllib3.fields import RequestField  # type: ignore
 from urllib3.filepost import encode_multipart_formdata  # type: ignore
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.exceptions import LookasideCacheError, DownloadError
 from rebasehelper.logger import CustomLogger
 from rebasehelper.helpers.download_helper import DownloadHelper
@@ -63,7 +64,7 @@ class LookasideCacheHelper:
         sources = []
         path = os.path.join(basepath, 'sources')
         if os.path.isfile(path):
-            with open(path, 'r') as f:
+            with open(path, 'r', encoding=ENCODING) as f:
                 for line in f.readlines():
                     line = line.strip()
                     m = line_re.match(line)
@@ -82,7 +83,7 @@ class LookasideCacheHelper:
     @classmethod
     def _write_sources(cls, basepath, sources):
         path = os.path.join(basepath, 'sources')
-        with open(path, 'w') as f:
+        with open(path, 'w', encoding=ENCODING) as f:
             for source in sources:
                 f.write('{0} ({1}) = {2}\n'.format(source['hashtype'].upper(), source['filename'], source['hash']))
 

--- a/rebasehelper/helpers/process_helper.py
+++ b/rebasehelper/helpers/process_helper.py
@@ -28,7 +28,7 @@ import subprocess
 import tempfile
 from typing import cast
 
-from rebasehelper.constants import SYSTEM_ENCODING
+from rebasehelper.constants import ENCODING
 from rebasehelper.logger import CustomLogger
 
 
@@ -140,7 +140,7 @@ class ProcessHelper:
 
         # read the input from a file/file-like object?
         try:
-            in_file = open(input_file, 'r')
+            in_file = open(input_file, 'r', encoding=ENCODING)
         except TypeError:
             in_file = input_file
         else:
@@ -163,7 +163,7 @@ class ProcessHelper:
             except AttributeError:
                 spooled_in_file.close()
             else:
-                spooled_in_file.write(in_data.encode(SYSTEM_ENCODING))
+                spooled_in_file.write(in_data.encode(ENCODING))
                 spooled_in_file.seek(0)
                 in_file = spooled_in_file
                 close_in_file = True
@@ -193,7 +193,7 @@ class ProcessHelper:
             # read the output
             for line in sp.stdout:
                 try:
-                    out_file.write(line.decode(SYSTEM_ENCODING))
+                    out_file.write(line.decode(ENCODING))
                 except TypeError:
                     out_file.write(line)
             # TODO: Need to figure out how to send output to stdout (without logger) and to logger

--- a/rebasehelper/helpers/rpm_helper.py
+++ b/rebasehelper/helpers/rpm_helper.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, cast
 
 import rpm  # type: ignore
 
-from rebasehelper.constants import SYSTEM_ENCODING
+from rebasehelper.constants import ENCODING
 from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.logger import CustomLogger
 from rebasehelper.helpers.macro_helper import MacroHelper
@@ -48,7 +48,7 @@ class RpmHeader:
     def __getattr__(self, item: str) -> Any:
         def decode(s):
             if isinstance(s, bytes):
-                return s.decode(SYSTEM_ENCODING)
+                return s.decode(ENCODING)
             return s
         result = getattr(self.hdr, item)
         if isinstance(result, list):
@@ -127,7 +127,7 @@ class RpmHelper:
         ts = rpm.TransactionSet()
         # disable signature checking
         ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES)  # pylint: disable=protected-access
-        with open(rpm_name, "r") as f:
+        with open(rpm_name, "r", encoding=ENCODING) as f:
             hdr = ts.hdrFromFdno(f)
         return RpmHeader(hdr)
 

--- a/rebasehelper/patcher.py
+++ b/rebasehelper/patcher.py
@@ -35,7 +35,7 @@ import unidiff  # type: ignore
 from rebasehelper.specfile import PatchObject
 from rebasehelper.helpers.git_helper import GitHelper
 from rebasehelper.helpers.input_helper import InputHelper
-from rebasehelper.constants import SYSTEM_ENCODING
+from rebasehelper.constants import ENCODING
 from rebasehelper.logger import CustomLogger
 
 
@@ -71,7 +71,7 @@ class Patcher:
 
     @classmethod
     def strip_patch_name(cls, diff, patch_name):
-        token = '\n\n{0}'.format(cls.decorate_patch_name(patch_name)).encode(SYSTEM_ENCODING)
+        token = '\n\n{0}'.format(cls.decorate_patch_name(patch_name)).encode(ENCODING)
         try:
             idx = diff.index(token)
             return diff[:idx] + diff[idx + len(token):]
@@ -204,14 +204,14 @@ class Patcher:
                     break
             try:
                 if os.path.isdir(os.path.join(cls.old_sources, '.git', 'rebase-merge')):
-                    with open(os.path.join(cls.old_sources, '.git', 'rebase-merge', 'msgnum')) as f:
+                    with open(os.path.join(cls.old_sources, '.git', 'rebase-merge', 'msgnum'), encoding=ENCODING) as f:
                         next_index = int(f.readline())
-                    with open(os.path.join(cls.old_sources, '.git', 'rebase-merge', 'end')) as f:
+                    with open(os.path.join(cls.old_sources, '.git', 'rebase-merge', 'end'), encoding=ENCODING) as f:
                         last_index = int(f.readline())
                 else:
-                    with open(os.path.join(cls.old_sources, '.git', 'rebase-apply', 'next')) as f:
+                    with open(os.path.join(cls.old_sources, '.git', 'rebase-apply', 'next'), encoding=ENCODING) as f:
                         next_index = int(f.readline())
-                    with open(os.path.join(cls.old_sources, '.git', 'rebase-apply', 'last')) as f:
+                    with open(os.path.join(cls.old_sources, '.git', 'rebase-apply', 'last'), encoding=ENCODING) as f:
                         last_index = int(f.readline())
             except (FileNotFoundError, IOError) as e:
                 raise RuntimeError('Git rebase failed with unknown reason. Please check log file') from e

--- a/rebasehelper/plugins/build_log_hooks/files.py
+++ b/rebasehelper/plugins/build_log_hooks/files.py
@@ -34,7 +34,7 @@ from rebasehelper.logger import CustomLogger
 from rebasehelper.plugins.build_log_hooks import BaseBuildLogHook
 from rebasehelper.types import PackageCategories
 from rebasehelper.helpers.macro_helper import MacroHelper
-from rebasehelper.constants import NEW_BUILD_DIR
+from rebasehelper.constants import NEW_BUILD_DIR, ENCODING
 from rebasehelper.specfile import SpecFile
 
 
@@ -132,7 +132,7 @@ class Files(BaseBuildLogHook):
 
         """
         try:
-            with open(log_path, 'r') as build_log:
+            with open(log_path, 'r', encoding=ENCODING) as build_log:
                 lines = build_log.read().splitlines()
         except IOError:
             logger.error('There was an error opening %s', log_path)

--- a/rebasehelper/plugins/checkers/abipkgdiff.py
+++ b/rebasehelper/plugins/checkers/abipkgdiff.py
@@ -27,6 +27,7 @@ import os
 import re
 from typing import Dict, Optional, cast
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.exceptions import RebaseHelperError, CheckerNotFoundError
 from rebasehelper.logger import CustomLogger
 from rebasehelper.results_store import results_store
@@ -203,7 +204,7 @@ class AbiPkgDiff(BaseChecker):
         pkgs = {}
         for pkg, ret_code in ret_codes.items():
             if ret_code & cls.ABIDIFF_ABI_CHANGE:
-                with open(os.path.join(cls.results_dir, pkg + '.txt'), 'r') as f:
+                with open(os.path.join(cls.results_dir, pkg + '.txt'), 'r', encoding=ENCODING) as f:
                     pkgs[pkg] = parse_changes(f.readlines())
         return pkgs
 

--- a/rebasehelper/plugins/checkers/licensecheck.py
+++ b/rebasehelper/plugins/checkers/licensecheck.py
@@ -27,6 +27,7 @@ import os
 import re
 from typing import Dict, List, Optional
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.helpers.process_helper import ProcessHelper
 from rebasehelper.plugins.checkers import BaseChecker, CheckerCategory
 
@@ -180,7 +181,7 @@ class LicenseCheck(BaseChecker):
         else:
             output_string.append('No license changes detected.')
 
-        with open(report_file_path, 'w') as f:
+        with open(report_file_path, 'w', encoding=ENCODING) as f:
             f.write('\n'.join(output_string))
 
     @classmethod

--- a/rebasehelper/plugins/checkers/pkgdiff.py
+++ b/rebasehelper/plugins/checkers/pkgdiff.py
@@ -27,6 +27,7 @@ import os
 from typing import Dict, List, Optional, cast
 from xml.etree import ElementTree
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.exceptions import RebaseHelperError, CheckerNotFoundError
 from rebasehelper.logger import CustomLogger
 from rebasehelper.results_store import results_store
@@ -89,7 +90,7 @@ class PkgDiff(BaseChecker):
             lines.append('<{0}>\n{1}\n</{0}>\n'.format(key, new_value))
 
         try:
-            with open(file_name, 'w') as f:
+            with open(file_name, 'w', encoding=ENCODING) as f:
                 f.writelines(lines)
         except IOError as e:
             raise RebaseHelperError("Unable to create XML file for pkgdiff tool '{}'".format(file_name)) from e
@@ -128,7 +129,7 @@ class PkgDiff(BaseChecker):
         for file_name in [os.path.join(result_dir, x) for x in XML_FILES]:
             logger.verbose('Processing %s file.', file_name)
             try:
-                with open(file_name, "r") as f:
+                with open(file_name, "r", encoding=ENCODING) as f:
                     lines = ['<pkgdiff>']
                     lines.extend(f.readlines())
                     lines.append('</pkgdiff>')
@@ -244,7 +245,7 @@ class PkgDiff(BaseChecker):
 
         pkgdiff_report = os.path.join(cls.results_dir, cls.pkgdiff_results_filename + '.txt')
         try:
-            with open(pkgdiff_report, "w") as f:
+            with open(pkgdiff_report, "w", encoding=ENCODING) as f:
                 f.write('\n'.join(lines))
         except IOError as e:
             raise RebaseHelperError("Unable to write result from {} to '{}'".format(cls.name, pkgdiff_report)) from e

--- a/rebasehelper/plugins/checkers/rpmdiff.py
+++ b/rebasehelper/plugins/checkers/rpmdiff.py
@@ -28,6 +28,7 @@ import os
 import re
 from typing import Dict, List, Optional, cast
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.exceptions import RebaseHelperError, CheckerNotFoundError
 from rebasehelper.logger import CustomLogger
 from rebasehelper.results_store import results_store
@@ -155,7 +156,7 @@ class RpmDiff(BaseChecker):
         counts = {k: len(v) for k, v in results_dict.items()}
 
         try:
-            with open(rpmdiff_report, "w") as f:
+            with open(rpmdiff_report, "w", encoding=ENCODING) as f:
                 f.write('\n'.join(lines))
         except IOError as e:
             raise RebaseHelperError("Unable to write result from {} to '{}'".format(cls.name, rpmdiff_report)) from e

--- a/rebasehelper/plugins/checkers/rpminspect.py
+++ b/rebasehelper/plugins/checkers/rpminspect.py
@@ -27,6 +27,7 @@ import json
 
 from typing import Any, Dict, Tuple
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.exceptions import CheckerNotFoundError, RebaseHelperError
 from rebasehelper.helpers.rpm_helper import RpmHelper
 from rebasehelper.helpers.process_helper import ProcessHelper
@@ -136,7 +137,7 @@ class Rpminspect(BaseChecker):  # pylint: disable=abstract-method
         if ret not in (0, 1):
             raise RebaseHelperError('An error occurred when running checker \'{}\''.format(cls.name))
 
-        with open(outfile, 'r') as json_file:
+        with open(outfile, 'r', encoding=ENCODING) as json_file:
             data = json.load(json_file)
 
         return outfile, cls.process_data(data)

--- a/rebasehelper/plugins/output_tools/json_.py
+++ b/rebasehelper/plugins/output_tools/json_.py
@@ -24,6 +24,7 @@
 
 import json
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.plugins.output_tools import BaseOutputTool
 from rebasehelper.results_store import results_store
 
@@ -42,7 +43,7 @@ class JSON(BaseOutputTool):
             results: Results store instance to get the data from.
 
         """
-        with open(report_path, 'w') as outputfile:
+        with open(report_path, 'w', encoding=ENCODING) as outputfile:
             json.dump(results.get_all(), outputfile, indent=4, sort_keys=True)
 
     @classmethod

--- a/rebasehelper/plugins/spec_hooks/ruby_helper.py
+++ b/rebasehelper/plugins/spec_hooks/ruby_helper.py
@@ -28,6 +28,7 @@ import re
 import urllib.parse
 from typing import cast
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.logger import CustomLogger
 from rebasehelper.plugins.spec_hooks import BaseSpecHook
 from rebasehelper.temporary_environment import TemporaryEnvironment
@@ -62,7 +63,7 @@ class RubyHelper(BaseSpecHook):
         logger.info("Attempting to create source '%s' using instructions in comments", source)
         with TemporaryEnvironment() as tmp:
             script = os.path.join(tmp.path(), 'script.sh')
-            with open(script, 'w') as f:
+            with open(script, 'w', encoding=ENCODING) as f:
                 f.write('#!/bin/sh -x\n')
                 f.write('{}\n'.format('\n'.join(instructions)))
                 f.write('cp "{}" "{}"\n'.format(source, os.getcwd()))

--- a/rebasehelper/sample_config.py
+++ b/rebasehelper/sample_config.py
@@ -28,7 +28,7 @@ from argparse import SUPPRESS
 from typing import List
 
 from rebasehelper.cli import CLI
-from rebasehelper.constants import CONFIG_PATH, CONFIG_FILENAME
+from rebasehelper.constants import CONFIG_PATH, CONFIG_FILENAME, ENCODING
 
 
 class SampleConfig:
@@ -76,7 +76,7 @@ def main():
     if len(sys.argv) != 2:
         return 1
     s = SampleConfig.generate()
-    with open(sys.argv[1], 'w') as f:
+    with open(sys.argv[1], 'w', encoding=ENCODING) as f:
         f.write(s)
     return 0
 

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -986,7 +986,7 @@ class SpecFile:
 
         """
         try:
-            with open(self.path) as f:
+            with open(self.path, encoding=constants.ENCODING) as f:
                 content = f.read()
         except IOError as e:
             raise RebaseHelperError("Unable to open and read SPEC file '{}'".format(self.path)) from e
@@ -996,7 +996,7 @@ class SpecFile:
         """Writes the current state of SpecContent into a file."""
         logger.verbose("Writing SPEC file '%s' to the disc", self.path)
         try:
-            with open(self.path, "w") as f:
+            with open(self.path, "w", encoding=constants.ENCODING) as f:
                 f.write(str(self.spec_content))
         except IOError as e:
             raise RebaseHelperError("Unable to write updated data to SPEC file '{}'".format(self.path)) from e

--- a/rebasehelper/tests/functional/conftest.py
+++ b/rebasehelper/tests/functional/conftest.py
@@ -26,7 +26,7 @@ import os
 
 import pytest  # type: ignore
 
-from rebasehelper.constants import RESULTS_DIR, DEBUG_LOG, CHANGES_PATCH, REPORT
+from rebasehelper.constants import RESULTS_DIR, DEBUG_LOG, CHANGES_PATCH, REPORT, ENCODING
 
 
 def make_artifacts_report():
@@ -46,7 +46,7 @@ def make_artifacts_report():
     report = []
     for artifact in artifacts:
         try:
-            with open(os.path.join(RESULTS_DIR, artifact)) as f:
+            with open(os.path.join(RESULTS_DIR, artifact), encoding=ENCODING) as f:
                 content = f.read()
                 report.append(' {} '.format(artifact).center(80, '_'))
                 report.append(content)

--- a/rebasehelper/tests/functional/test_rebase.py
+++ b/rebasehelper/tests/functional/test_rebase.py
@@ -34,7 +34,7 @@ from typing import List
 from rebasehelper.cli import CLI
 from rebasehelper.config import Config
 from rebasehelper.application import Application
-from rebasehelper.constants import RESULTS_DIR, CHANGES_PATCH
+from rebasehelper.constants import RESULTS_DIR, CHANGES_PATCH, ENCODING
 from rebasehelper.helpers.git_helper import GitHelper
 
 
@@ -118,7 +118,7 @@ class TestRebase:
         assert [h for h in spec_file if '-Patch2:         backported.patch\n' in h.source]
         assert [h for h in spec_file if '-%patch2 -p1\n' in h.source]
         assert [h for h in spec_file if '+- New upstream release {}\n'.format(new_version) in h.target]
-        with open(os.path.join(RESULTS_DIR, 'report.json')) as f:
+        with open(os.path.join(RESULTS_DIR, 'report.json'), encoding=ENCODING) as f:
             report = json.load(f)
             assert 'success' in report['result']
             # patches
@@ -203,7 +203,7 @@ class TestRebase:
         assert [h for h in spec_file if '+%{_datadir}/%{name}/2.dat\n' in h.target]
         assert [h for h in spec_file if '+%{_datadir}/%{name}/extra/D.dat\n' in h.target]
 
-        with open(os.path.join(RESULTS_DIR, 'report.json')) as f:
+        with open(os.path.join(RESULTS_DIR, 'report.json'), encoding=ENCODING) as f:
             report = json.load(f)
             assert 'success' in report['result']
             # files build log hook

--- a/rebasehelper/tests/helpers/test_download_helper.py
+++ b/rebasehelper/tests/helpers/test_download_helper.py
@@ -27,6 +27,7 @@ import os
 
 import pytest  # type: ignore
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.helpers.download_helper import DownloadHelper, DownloadError
 
 
@@ -91,7 +92,7 @@ class TestDownloadHelper:
         local_file = 'local_file'
         DownloadHelper.download_file(url, local_file)
         assert os.path.isfile(local_file)
-        with open(local_file) as f:
+        with open(local_file, encoding=ENCODING) as f:
             assert f.readline().strip() == content
 
     @pytest.mark.parametrize('url', [

--- a/rebasehelper/tests/helpers/test_git_helper.py
+++ b/rebasehelper/tests/helpers/test_git_helper.py
@@ -27,13 +27,14 @@ import os
 import git  # type: ignore
 import pytest  # type: ignore
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.helpers.git_helper import GitHelper
 
 
 class TestGitHelper:
 
     def write_config_file(self, config_file, name, email):
-        with open(config_file, 'w') as f:
+        with open(config_file, 'w', encoding=ENCODING) as f:
             f.write('[user]\n'
                     '    name = {0}\n'
                     '    email = {1}\n'.format(name, email))
@@ -67,7 +68,7 @@ class TestGitHelper:
                 os.makedirs(work_git_path)
 
                 config_file = os.path.join(work_git_path, 'config')
-                with open(config_file, 'w') as f:
+                with open(config_file, 'w', encoding=ENCODING) as f:
                     f.write('[include]\n'
                             '    path = included_config\n')
                 included_config_file = os.path.join(work_git_path, 'included_config')

--- a/rebasehelper/tests/helpers/test_path_helper.py
+++ b/rebasehelper/tests/helpers/test_path_helper.py
@@ -26,6 +26,7 @@ import os
 
 import pytest  # type: ignore
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.helpers.path_helper import PathHelper
 
 
@@ -54,7 +55,7 @@ class TestPathHelper:
                 os.makedirs(os.path.dirname(f))
             except OSError:
                 pass
-            with open(f, 'w') as fd:
+            with open(f, 'w', encoding=ENCODING) as fd:
                 fd.write(f)
 
         return files

--- a/rebasehelper/tests/helpers/test_process_helper.py
+++ b/rebasehelper/tests/helpers/test_process_helper.py
@@ -29,6 +29,7 @@ import string
 
 from typing import List
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.helpers.process_helper import ProcessHelper
 
 
@@ -57,7 +58,7 @@ class TestProcessHelper:
                                                output_file=self.OUT_FILE)
             assert ret == 0
             assert os.path.exists(self.OUT_FILE)
-            assert open(self.OUT_FILE).readline().strip('\n') == self.PHRASE
+            assert open(self.OUT_FILE, encoding=ENCODING).readline().strip('\n') == self.PHRASE
 
         def test_simple_cmd_with_redirected_output_fileobject(self):
             buff = io.StringIO()
@@ -69,18 +70,18 @@ class TestProcessHelper:
             buff.close()
 
         def test_simple_cmd_with_input_path_and_redirected_output_path(self):
-            with open(self.IN_FILE, 'w') as f:
+            with open(self.IN_FILE, 'w', encoding=ENCODING) as f:
                 f.write(self.PHRASE)
 
             assert os.path.exists(self.IN_FILE)
-            assert open(self.IN_FILE).readline().strip('\n') == self.PHRASE
+            assert open(self.IN_FILE, encoding=ENCODING).readline().strip('\n') == self.PHRASE
 
             ret = ProcessHelper.run_subprocess(self.CAT_COMMAND,
                                                input_file=self.IN_FILE,
                                                output_file=self.OUT_FILE)
             assert ret == 0
             assert os.path.exists(self.OUT_FILE)
-            assert open(self.OUT_FILE).readline().strip('\n') == self.PHRASE
+            assert open(self.OUT_FILE, encoding=ENCODING).readline().strip('\n') == self.PHRASE
 
         def test_simple_cmd_with_input_fileobject_and_redirected_output_path(self):
             in_buff = io.StringIO()
@@ -96,15 +97,15 @@ class TestProcessHelper:
             in_buff.close()
             assert ret == 0
             assert os.path.exists(self.OUT_FILE)
-            assert open(self.OUT_FILE).readline().strip('\n') == self.PHRASE
+            assert open(self.OUT_FILE, encoding=ENCODING).readline().strip('\n') == self.PHRASE
 
         def test_simple_cmd_with_input_path_and_redirected_output_fileobject(self):
             out_buff = io.StringIO()
-            with open(self.IN_FILE, 'w') as f:
+            with open(self.IN_FILE, 'w', encoding=ENCODING) as f:
                 f.write(self.PHRASE)
 
             assert os.path.exists(self.IN_FILE)
-            assert open(self.IN_FILE).readline().strip('\n') == self.PHRASE
+            assert open(self.IN_FILE, encoding=ENCODING).readline().strip('\n') == self.PHRASE
 
             ret = ProcessHelper.run_subprocess(self.CAT_COMMAND,
                                                input_file=self.IN_FILE,
@@ -160,7 +161,7 @@ class TestProcessHelper:
             assert ret == 0
             assert os.path.exists(os.path.join(self.TEMP_DIR, self.TEMP_FILE))
             assert os.path.exists(self.OUT_FILE)
-            assert open(self.OUT_FILE).readline().strip("\n") == self.TEMP_FILE
+            assert open(self.OUT_FILE, encoding=ENCODING).readline().strip("\n") == self.TEMP_FILE
 
     class TestRunSubprocessCwdEnv:
         """ ProcessHelper - run_subprocess_cwd_env() tests """
@@ -184,7 +185,7 @@ class TestProcessHelper:
                                                        shell=True)
             assert ret == 0
             assert os.path.exists(self.OUT_FILE)
-            assert open(self.OUT_FILE).readline().strip("\n") == self.PHRASE
+            assert open(self.OUT_FILE, encoding=ENCODING).readline().strip("\n") == self.PHRASE
 
         def test_setting_existing_env(self):
             # make copy of existing environment
@@ -203,4 +204,4 @@ class TestProcessHelper:
                                                        shell=True)
             assert ret == 0
             assert os.path.exists(self.OUT_FILE)
-            assert open(self.OUT_FILE).readline().strip("\n") == self.PHRASE
+            assert open(self.OUT_FILE, encoding=ENCODING).readline().strip("\n") == self.PHRASE

--- a/rebasehelper/tests/plugins/test_output_tools.py
+++ b/rebasehelper/tests/plugins/test_output_tools.py
@@ -27,6 +27,7 @@ import os
 
 import pytest  # type: ignore
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.plugins.output_tools.json_ import JSON
 from rebasehelper.plugins.output_tools.text import Text
 from rebasehelper.plugins.plugin_manager import plugin_manager
@@ -183,7 +184,7 @@ Binary packages and logs are in directory rebase-helper-results/new-build/RPM:
         assert Text.name in plugin_manager.output_tools.plugins
         Text.print_summary(results_file_path, results_store)
 
-        with open(results_file_path) as f:
+        with open(results_file_path, encoding=ENCODING) as f:
             lines = [y.strip() for y in f.readlines()]
             assert lines == self.get_expected_text_output(os.path.dirname(results_file_path)).split('\n')
 
@@ -191,7 +192,7 @@ Binary packages and logs are in directory rebase-helper-results/new-build/RPM:
         assert JSON.name in plugin_manager.output_tools.plugins
         JSON.print_summary(results_file_path, results_store)
 
-        with open(results_file_path) as f:
+        with open(results_file_path, encoding=ENCODING) as f:
             json_dict = json.load(f)
             # in Python2 strings in json decoded dict are Unicode, which would make the test fail
             assert json_dict == json.loads(json.dumps(self.get_expected_json_output()))

--- a/rebasehelper/tests/test_application.py
+++ b/rebasehelper/tests/test_application.py
@@ -153,9 +153,9 @@ class TestApplication:
         'gitignore',
     ])
     def test_update_gitignore(self, workdir, gitignore, sources, result):
-        with open(os.path.join(workdir, '.gitignore'), 'w') as f:
+        with open(os.path.join(workdir, '.gitignore'), 'w', encoding=constants.ENCODING) as f:
             for line in gitignore:
                 f.write(line)
         Application._update_gitignore(sources, workdir)  # pylint: disable=protected-access
-        with open(os.path.join(workdir, '.gitignore')) as f:
+        with open(os.path.join(workdir, '.gitignore'), encoding=constants.ENCODING) as f:
             assert f.readlines() == result

--- a/rebasehelper/tests/test_archive.py
+++ b/rebasehelper/tests/test_archive.py
@@ -29,6 +29,7 @@ import pytest  # type: ignore
 from typing import List
 
 from rebasehelper.archive import Archive
+from rebasehelper.constants import ENCODING
 
 
 class TestArchive:
@@ -95,7 +96,7 @@ class TestArchive:
         #  check if the file was extracted
         assert os.path.isfile(extracted_file)
         #  check the content
-        with open(extracted_file) as f:
+        with open(extracted_file, encoding=ENCODING) as f:
             assert f.read().strip() == self.ARCHIVED_FILE_CONTENT
 
     @pytest.mark.parametrize('archive', [

--- a/rebasehelper/tests/test_config.py
+++ b/rebasehelper/tests/test_config.py
@@ -29,6 +29,7 @@ import pytest  # type: ignore
 
 from rebasehelper.cli import CLI
 from rebasehelper.config import Config
+from rebasehelper.constants import ENCODING
 
 
 class TestConfig:
@@ -40,7 +41,7 @@ class TestConfig:
         config.add_section('Section1')
         for key, value in config_args.items():
             config.set('Section1', key, value)
-        with open(self.CONFIG_FILE, 'w') as configfile:
+        with open(self.CONFIG_FILE, 'w', encoding=ENCODING) as configfile:
             config.write(configfile)
 
         return os.path.abspath(self.CONFIG_FILE)

--- a/rebasehelper/tests/test_patcher.py
+++ b/rebasehelper/tests/test_patcher.py
@@ -30,6 +30,7 @@ import pytest  # type: ignore
 
 from typing import List
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.patcher import Patcher
 from rebasehelper.specfile import PatchObject
 
@@ -132,7 +133,7 @@ class TestPatcher:
             assert patches['modified'] == [os.path.basename(self.PATCH2)]
             assert patches['deleted'] == [os.path.basename(self.PATCH4)]
             assert patches['inapplicable'] == [os.path.basename(self.PATCH3)]
-        with open(os.path.join(rebased_sources, os.path.basename(self.PATCH2))) as f:
+        with open(os.path.join(rebased_sources, os.path.basename(self.PATCH2)), encoding=ENCODING) as f:
             content = f.read()
             assert 'From: {0} <{1}>\n'.format(self.USER, self.EMAIL) in content
             assert 'Subject: [PATCH] P2\n' in content

--- a/rebasehelper/tests/test_spec_content.py
+++ b/rebasehelper/tests/test_spec_content.py
@@ -24,6 +24,7 @@
 
 import pytest  # type: ignore
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.spec_content import SpecContent
 from rebasehelper.tests.conftest import SPEC_FILE
 
@@ -35,11 +36,11 @@ class TestSpecContent:
 
     @pytest.fixture
     def spec_content(self):
-        with open(SPEC_FILE, 'r') as infile:
+        with open(SPEC_FILE, 'r', encoding=ENCODING) as infile:
             return SpecContent(infile.read())
 
     def test_string_representation(self, spec_content):
-        with open(SPEC_FILE, 'r') as infile:
+        with open(SPEC_FILE, 'r', encoding=ENCODING) as infile:
             assert str(spec_content) == infile.read()
 
     @pytest.mark.parametrize('line, section, expected', [

--- a/rebasehelper/tests/test_temporary_environment.py
+++ b/rebasehelper/tests/test_temporary_environment.py
@@ -25,6 +25,7 @@
 import os
 import tempfile
 
+from rebasehelper.constants import ENCODING
 from rebasehelper.temporary_environment import TemporaryEnvironment
 
 
@@ -64,13 +65,13 @@ class TestTemporaryEnvironment:
         def callback(**kwargs):
             path = kwargs.get(TemporaryEnvironment.TEMPDIR, '')
             assert path != ''
-            with open(tmp_path, 'w') as f:
+            with open(tmp_path, 'w', encoding=ENCODING) as f:
                 f.write(path)
 
         with TemporaryEnvironment(exit_callback=callback) as temp:
             path = temp.path()
 
-        with open(tmp_path, 'r') as f:
+        with open(tmp_path, 'r', encoding=ENCODING) as f:
             assert f.read() == path
 
         os.unlink(tmp_path)
@@ -83,7 +84,7 @@ class TestTemporaryEnvironment:
         def callback(**kwargs):
             path = kwargs.get(TemporaryEnvironment.TEMPDIR, '')
             assert path != ''
-            with open(tmp_path, 'w') as f:
+            with open(tmp_path, 'w', encoding=ENCODING) as f:
                 f.write(path)
 
         try:
@@ -93,7 +94,7 @@ class TestTemporaryEnvironment:
         except RuntimeError:
             pass
 
-        with open(tmp_path, 'r') as f:
+        with open(tmp_path, 'r', encoding=ENCODING) as f:
             assert f.read() == path
 
         os.unlink(tmp_path)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def get_requirements():
 
 
 def get_readme():
-    with open('README.md') as f:
+    with open('README.md', encoding='utf-8') as f:
         return f.read()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,6 @@ commands=
            --disable=C,R \
            --disable=fixme \
            --disable=locally-disabled \
-           # temporary workaround, see https://github.com/PyCQA/pylint/issues/3760
-           --disable=unsubscriptable-object \
            rebasehelper
     mypy rebasehelper
     -mypy --check-untyped-defs rebasehelper


### PR DESCRIPTION
Use system encoding (will usually be UTF-8) everywhere but setup.py (where README is read) -- use hardcoded UTF-8 there since the file comes from our repository.

Also interestingly, the tests on rawhide no longer fail on this branch?