### PR TITLE
Use long options with rpmdiff

### DIFF
--- a/rebasehelper/plugins/checkers/rpmdiff.py
+++ b/rebasehelper/plugins/checkers/rpmdiff.py
@@ -127,7 +127,7 @@ class RpmDiff(BaseChecker):
             cmd = [cls.CMD]
             # TODO modify to online command
             for x in not_catched_flags:
-                cmd.extend(['-i', x])
+                cmd.extend(['--ignore={0}'.format(x)])
             cmd.append(value)
             # We would like to build correct old package against correct new packages
             try:


### PR DESCRIPTION
It seems there is a bug in rpmdiff argument parsing, however long options still work correctly, and they are more verbose, so just use them.