### PR TITLE
spec: sources may not be defined

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -235,7 +235,10 @@ class SpecFile:
     ###########################
 
     @staticmethod
-    def _identify_main_source(spec: rpm.spec) -> int:
+    def _identify_main_source(spec: rpm.spec) -> Optional[int]:
+        # a spec file does not need to have sources
+        if not spec.sources:
+            return None
         # lowest index is the main source
         return min([s[1] for s in spec.sources if s[2] == 1])
 
@@ -270,11 +273,14 @@ class SpecFile:
         """
         return os.path.basename(self.get_sources()[0])
 
-    def _get_raw_source_string(self, source_num: int) -> Optional[str]:
+    def _get_raw_source_string(self, source_num: Optional[int]) -> Optional[str]:
+        if source_num is None:
+            return None
         tag = 'Source{0}'.format(source_num)
         return self.get_raw_tag_value(tag)
 
     def get_main_source(self) -> str:
+        """Provide the main source, returns empty string if there are no sources"""
         return self._get_raw_source_string(self.main_source_index) or ''
 
     ###########################

--- a/rebasehelper/tests/test_specfile.py
+++ b/rebasehelper/tests/test_specfile.py
@@ -102,6 +102,7 @@ class TestSpecFile:
         # pylint: disable=protected-access
         for i, source in enumerate(sources):
             assert mocked_spec_object._get_raw_source_string(i) == source
+        assert mocked_spec_object._get_raw_source_string(None) == None
 
     def test_old_tarball(self, spec_object):
         assert spec_object.get_archive() == self.OLD_ARCHIVE


### PR DESCRIPTION
there can be spec files which are meant to define dependencies only thus
they ship no files and have no sources

Please let me know where should I create a test case.

https://sentry.io/share/issue/1e27f7ad5acd49c29f2c27957741ebb4/