### PR TITLE
Remove any existing submodule configuration before rebasing

### DIFF
--- a/rebasehelper/patcher.py
+++ b/rebasehelper/patcher.py
@@ -332,6 +332,11 @@ class Patcher:
     def init_git(cls, directory):
         """Function initialize old and new Git repository"""
         try:
+            # remove any existing submodule configuration
+            os.remove(os.path.join(directory, '.gitmodules'))
+        except FileNotFoundError:
+            pass
+        try:
             repo = git.Repo(directory)
             try:
                 state = repo.git.config('rebasehelper.state', get=True, local=True)


### PR DESCRIPTION
Some tarballs contain additional git metadata such as submodule config.
If it exists and submodules are not checked out, certain GitPython functions traceback. Avoid that.