### PR TITLE
packit: use bumpspec to update spec

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -15,3 +15,6 @@ actions:
   create-archive:
   - "python3 setup.py sdist --base-name rebase-helper --dist-dir ."
   - "bash -c 'ls -1t ./rebase-helper-*.tar.gz | head -n 1'"
+  fix-spec-file:
+  - bash -c "rpmdev-bumpspec -c \"Rebuild $PACKIT_PROJECT_COMMIT\" -n $(python3 setup.py --version) ./rebase-helper.spec"
+copy_upstream_release_description: true


### PR DESCRIPTION
...during the CI builds

Resolves: https://github.com/packit/packit/issues/1520

The problem is that a macro `%dump` which comes from a commit title is
interpreted and makes the spec unparsable.