### PR TITLE
Add support for rpmuncompress

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -30,14 +30,6 @@ unsafe-load-any-extension=no
 # run arbitrary code
 extension-pkg-whitelist=rpm
 
-# Allow optimization of some AST trees. This will activate a peephole AST
-# optimizer, which will apply various small optimizations. For instance, it can
-# be used to obtain the result of joining multiple strings with the addition
-# operator. Joining a lot of strings can lead to a maximum recursion error in
-# Pylint and this flag can prevent that. It has one side effect, the resulting
-# AST will be different than the one from reality.
-optimize-ast=no
-
 
 [MESSAGES CONTROL]
 
@@ -68,11 +60,6 @@ confidence=
 # (visual studio) and html. You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=parseable
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=no
@@ -167,9 +154,6 @@ notes=FIXME,XXX,TODO
 
 [BASIC]
 
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,input
-
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,ex,Run,_
 
@@ -186,62 +170,32 @@ include-naming-hint=no
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,30}$
 
-# Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,30}$
-
 # Regular expression matching correct variable names
 variable-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct argument names
 argument-rgx=[a-z_][a-z0-9_]{2,30}$
 
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
 # Regular expression matching correct method names
 method-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
@@ -270,9 +224,6 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=no
-
-# List of optional constructs for which whitespace checking is disabled
-no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 max-module-lines=1000

--- a/rebasehelper/helpers/console_helper.py
+++ b/rebasehelper/helpers/console_helper.py
@@ -152,10 +152,11 @@ class ConsoleHelper:
 
         """
         prefix, suffix = query.split('?', 1)
-        attrs_obtained = False
         try:
             attrs = termios.tcgetattr(sys.stdin)
-            attrs_obtained = True
+        except termios.error:
+            return None
+        try:
             flags = fcntl.fcntl(sys.stdin.fileno(), fcntl.F_GETFL)
 
             # disable STDIN line buffering
@@ -181,9 +182,8 @@ class ConsoleHelper:
             return None
         finally:
             # set terminal settings to the starting point
-            if attrs_obtained:
-                termios.tcsetattr(sys.stdin, termios.TCSADRAIN, attrs)
-                fcntl.fcntl(sys.stdin.fileno(), fcntl.F_SETFL, flags)
+            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, attrs)
+            fcntl.fcntl(sys.stdin.fileno(), fcntl.F_SETFL, flags)
 
     class Capturer:
         """ContextManager for capturing stdout/stderr"""

--- a/rebasehelper/patcher.py
+++ b/rebasehelper/patcher.py
@@ -126,9 +126,9 @@ class Patcher:
                 except git.GitCommandError:
                     try:
                         repo.git.apply(sanitized_patch.name, p=patch_strip, reject=True, whitespace='fix')
-                    except git.GitCommandError as e:
+                    except git.GitCommandError as ee:
                         logger.verbose('Applying patch with git-apply failed.')
-                        logger.debug(str(e))
+                        logger.debug(str(ee))
                         raise
             repo.git.add(all=True)
             commit = repo.index.commit(cls.decorate_patch_name(os.path.basename(patch_name)), skip_hooks=True)

--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -1267,12 +1267,18 @@ class SpecFile:
                         parser = tar_parser
                     elif cmd == 'unzip':
                         parser = unzip_parser
+                    elif cmd == 'rpmuncompress':
+                        parser = None
+                        target = '.'
                     else:
                         continue
-                    try:
-                        ns, _ = parser.parse_known_args(args)
-                    except ParseError:
-                        continue
+                    if parser:
+                        try:
+                            ns, _ = parser.parse_known_args(args)
+                        except ParseError:
+                            continue
+                        else:
+                            target = ns.target
                     basedir = os.path.relpath(basedir, builddir)
-                    return os.path.normpath(os.path.join(basedir, ns.target))
+                    return os.path.normpath(os.path.join(basedir, target))
         return None


### PR DESCRIPTION
RPM >= 4.18 uses *rpmuncompress* rather than calling *tar* or *unzip* directly. Account for that in `SpecFile.find_archive_target_in_prep()`.

Solves FTBFS in Fedora Rawhide.