### PR TITLE
Update paths to modified patches in rebased spec file

### DIFF
--- a/rebasehelper/specfile.py
+++ b/rebasehelper/specfile.py
@@ -405,34 +405,34 @@ class SpecFile:
         removed_patches = []
         inapplicable_patches = []
         modified_patches = []
-        for patch in self.spec.patches().content: # pylint: disable=no-member
-            if 'deleted' in patches_dict:
-                patch_removed = [x for x in patches_dict['deleted'] if patch.expanded_filename in x]
-            else:
-                patch_removed = []
-            if 'inapplicable' in patches_dict:
-                patch_inapplicable = [x for x in patches_dict['inapplicable'] if patch.expanded_filename in x]
-            else:
-                patch_inapplicable = []
-            if patch_removed:
-                self.removed_patches.append(patch.expanded_filename)
-                removed_patches.append(patch.number)
-                continue
-            if patch_inapplicable:
-                inapplicable_patches.append(patch.number)
-            if 'modified' in patches_dict:
-                patch_modified = [x for x in patches_dict['modified'] if patch.expanded_filename in x]
-            else:
-                patch_modified = []
-            if patch_modified:
-                patch.location = os.path.join(constants.RESULTS_DIR,
-                                              constants.REBASED_SOURCES_DIR,
-                                              patch.expanded_filename)
-                modified_patches.append(patch.number)
-        self.process_patch_macros(comment_out=inapplicable_patches if disable_inapplicable else None,
-                                  remove=removed_patches, annotate=inapplicable_patches,
-                                  note='The following patch contains conflicts')
         with self.spec.patches() as patches:
+            for patch in patches:
+                if 'deleted' in patches_dict:
+                    patch_removed = [x for x in patches_dict['deleted'] if patch.expanded_filename in x]
+                else:
+                    patch_removed = []
+                if 'inapplicable' in patches_dict:
+                    patch_inapplicable = [x for x in patches_dict['inapplicable'] if patch.expanded_filename in x]
+                else:
+                    patch_inapplicable = []
+                if patch_removed:
+                    self.removed_patches.append(patch.expanded_filename)
+                    removed_patches.append(patch.number)
+                    continue
+                if patch_inapplicable:
+                    inapplicable_patches.append(patch.number)
+                if 'modified' in patches_dict:
+                    patch_modified = [x for x in patches_dict['modified'] if patch.expanded_filename in x]
+                else:
+                    patch_modified = []
+                if patch_modified:
+                    patch.location = os.path.join(constants.RESULTS_DIR,
+                                                  constants.REBASED_SOURCES_DIR,
+                                                  patch.expanded_filename)
+                    modified_patches.append(patch.number)
+            self.process_patch_macros(comment_out=inapplicable_patches if disable_inapplicable else None,
+                                      remove=removed_patches, annotate=inapplicable_patches,
+                                      note='The following patch contains conflicts')
             for number in removed_patches:
                 patches.remove_numbered(number)
             if disable_inapplicable:

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -373,11 +373,52 @@ class TestSpecFile:
             
             Patch2:     2.patch
             """),
-        )
+        ),
+        (
+            {
+                'removed_patches': [],
+                'spec_content': dedent("""\
+                    Patch0:    0.patch
+                    Patch1:    1.patch
+
+                    %patchlist
+                    2.patch
+                    3.patch
+
+                    %prep
+                    %patch0 -p0
+                    %patch1 -p1
+                    %patch2 -p2
+                    %patch3 -p3
+                    """),
+            },
+            {
+                'patches_dict':
+                    {
+                        'modified': ['1.patch', '2.patch'],
+                    },
+                'disable_inapplicable': False,
+            },
+            dedent("""\
+                Patch0:    0.patch
+                Patch1:    rebase-helper-results/rebased-sources/1.patch
+
+                %patchlist
+                rebase-helper-results/rebased-sources/2.patch
+                3.patch
+
+                %prep
+                %patch0 -p0
+                %patch1 -p1
+                %patch2 -p2
+                %patch3 -p3
+                """)
+        ),
     ], ids=[
         'do_not_disable_inapplicable',
         'disable_inapplicable',
-        'comments_and_blank_lines'
+        'comments_and_blank_lines',
+        'modified_patches'
     ])
     def test_write_updated_patches(self, mocked_spec_object, kwargs, expected_content):
         mocked_spec_object.write_updated_patches(**kwargs)


### PR DESCRIPTION
The location was updated properly, but on a read-only object so the changes were thrown away.